### PR TITLE
fix: 5 bugs + limpiar referencias MVP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,6 @@ QTorres/
 │       │   └── canvas.red  # Block Diagram canvas (stub)
 │       └── panel/
 │           └── panel.red   # Front Panel (stub)
-├── MVP/
-│   └── QTorres-mvp.red     # MVP monolítico FUNCIONAL — referencia de implementación
 ├── examples/
 │   ├── suma-basica.qvi     # Ejemplo de VI simple
 │   ├── suma-subvi.qvi      # Ejemplo de sub-VI
@@ -67,10 +65,8 @@ QTorres/
 - Hit testing sobre bloques, puertos y wires
 - Stress test con 20 nodos y 15 wires fluido
 
-**El MVP monolítico funciona.** `MVP/QTorres-mvp.red` es referencia de implementación existente.
-
 **Los módulos `src/` son stubs documentados.** La arquitectura está diseñada pero sin implementar.
-El objetivo es implementar `src/` de forma modular usando el MVP como referencia.
+El objetivo es implementar `src/` de forma modular.
 
 **Próximo paso: Fase 1.** Empezar por Issue #22 (identidad visual) o Issue #20 (borrar wire/nodo).
 
@@ -158,8 +154,7 @@ qvi-diagram: [
 ### Cómo trabajar un Issue
 1. Leer el Issue en GitHub (`gh issue view N --repo anlaco/QTorres`)
 2. Implementar en el módulo correspondiente de `src/`
-3. Usar `MVP/QTorres-mvp.red` como referencia de implementación existente
-4. Verificar con los ejemplos de `examples/`
+3. Verificar con los ejemplos de `examples/`
 5. Cerrar el Issue cuando esté completo (`gh issue close N --repo anlaco/QTorres`)
 
 ### Orden de los Issues (backlog)
@@ -205,9 +200,6 @@ Trabajar siempre en orden de Fase. No empezar Fase 1 sin completar Fase 0.
 ## Comandos útiles
 
 ```bash
-# Ejecutar el MVP
-red MVP/QTorres-mvp.red
-
 # Ejecutar un ejemplo
 red examples/suma-basica.qvi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,8 @@ Todo el código de QTorres está en Red-Lang. Ver [`CLAUDE.md`](CLAUDE.md) para 
 **Flujo de trabajo:**
 1. Crea un branch desde `main`
 2. Implementa en el módulo correspondiente de `src/`
-3. Usa `MVP/QTorres-mvp.red` como referencia de implementación existente
-4. Verifica con los ejemplos de `examples/`
-5. Abre un Pull Request
+3. Verifica con los ejemplos de `examples/`
+4. Abre un Pull Request
 
 ### 2. Contribuciones al backend GTK de Red (crítico para Linux)
 

--- a/QTorres.md
+++ b/QTorres.md
@@ -57,8 +57,6 @@ qtorres-diagram [
    
 Cargar un diagrama es load %mi-diagrama.qtorres. No hay parser que mantener.  
 ![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAnEAAAACCAYAAAA3pIp+AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAANklEQVR4nO3OQQmAABRAsScYxpg/i2XMYARvRrCCNxG2BFtmZquOAAD4i3Ot7mr/egIAwGvXA22YBcnkstSpAAAAAElFTkSuQmCC)  
-**MVP — producto mínimo viable**  
-El MVP demuestra el ciclo completo: dibujar → ejecutar → ver resultado.  
 **Bloques primitivos**  
 | | | |  
 |-|-|-|  
@@ -69,14 +67,13 @@ El MVP demuestra el ciclo completo: dibujar → ejecutar → ver resultado.
 | Multiplicación | operación | resultado: a * b |   
 | Display | salida | print valor |   
    
-**Funcionalidades del MVP**  
+**Funcionalidades**  
 - Canvas interactivo con bloques arrastrables (drag & drop)  
 - Conexión de bloques mediante wires dibujados a mano  
-- Front Panel con controles numéricos de entrada y displays de salida  
-- Botón Run que ejecuta el diagrama  
-- Botón Compile que genera el fichero .red  
-- Guardar y cargar diagramas en formato .qtorres  
-**Fuera del MVP**  
+- Hit testing sobre bloques, puertos y wires  
+- Renombrado de nodos con doble clic  
+- Borrado de nodos y wires con Delete  
+**Futuro**  
 - Bucles y estructuras de control  
 - Bloques de string y booleanos  
 - Bloques de I/O (ficheros, puertos serie, red)  

--- a/docs/ai-reference.md
+++ b/docs/ai-reference.md
@@ -2,7 +2,7 @@
 
 Este documento es una referencia de consumo para agentes de IA que necesiten generar ficheros del ecosistema QTorres. No es documentación interna del proyecto — es el contrato entre QTorres y cualquier modelo que genere ficheros para él.
 
-**Versión:** 1.1 — MVP (solo `.qvi` con tipos numéricos)
+**Versión:** 1.1 (solo `.qvi` con tipos numéricos)
 **Decisiones relacionadas:** DT-020, DT-021, DT-022, DT-023, DT-024
 
 ---
@@ -132,7 +132,7 @@ indicator [id: <int>  type: '<tipo>  name: "<name>"  label: [text: "<texto>" vis
 - `label` = objeto con `text` (editable por el usuario) y `visible` (controla si se muestra)
 - En controles e indicadores, `visible` es `true` por defecto
 
-**Tipos disponibles (MVP):** `'numeric`
+**Tipos disponibles:** `'numeric`
 
 ### Block Diagram — Nodos
 
@@ -174,7 +174,7 @@ wire [from: <id-nodo-origen>  port: '<puerto-salida>  to: <id-nodo-destino>  por
 **Reglas de conexión:**
 - Un puerto de salida puede conectarse a múltiples entradas (fan-out)
 - Un puerto de entrada solo puede recibir un wire (una sola fuente de datos)
-- Los tipos deben ser compatibles (en el MVP todo es `'number`)
+- Los tipos deben ser compatibles (todo es `'number`)
 - No se permiten ciclos en el grafo
 
 ### Connector (para sub-VIs)
@@ -395,4 +395,4 @@ qvi-diagram: [
 
 ## Nota sobre evolución
 
-Este documento refleja el estado del MVP (solo tipos numéricos). Conforme QTorres evolucione, se añadirán tipos de datos (`'boolean`, `'string`, `'array`), estructuras de control (loops, case), protocolos de hardware (Modbus, SCPI, MQTT), y nuevos bloques primitivos. La estructura del formato se mantiene — solo crece el vocabulario.
+Este documento refleja el estado actual de QTorres (tipos numéricos). Conforme evolucione, se añadirán tipos de datos (`'boolean`, `'string`, `'array`), estructuras de control (loops, case), protocolos de hardware (Modbus, SCPI, MQTT), y nuevos bloques primitivos.

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -39,21 +39,21 @@ Registro de decisiones clave del proyecto. Cada decisión documentada para refer
 
 ---
 
-## DT-003: MVP solo con tipos numéricos
+## DT-003: Tipos numéricos como punto de partida
 
 **Fecha:** 2026-03-14  
 **Estado:** Adoptada  
 
-**Contexto:** Definir el alcance mínimo del sistema de tipos para el MVP.
+**Contexto:** Definir el alcance mínimo del sistema de tipos.
 
-**Decisión:** El MVP solo maneja valores numéricos (`float!`). Un solo tipo de wire.
+**Decisión:** QTorres empieza manejando valores numéricos (`float!`). Un solo tipo de wire.
 
 **Razones:**
 - Simplifica el compilador (no hay conversiones de tipo)
 - Simplifica el canvas (un solo color de wire)
 - Suficiente para demostrar el concepto
 
-**Consecuencia:** La estructura de datos de puertos y wires DEBE incluir un campo `type` desde el inicio, aunque en el MVP siempre sea `'number`. Esto evita refactoring cuando se añadan strings y booleanos.
+**Consecuencia:** La estructura de datos de puertos y wires DEBE incluir un campo `type` desde el inicio, aunque en esta fase siempre sea `'number`. Esto evita refactoring cuando se añadan strings y booleanos.
 
 ---
 
@@ -72,7 +72,7 @@ Registro de decisiones clave del proyecto. Cada decisión documentada para refer
 - Al abrir cualquier fichero, en vez de un binario se encuentra Red legible
 - La extensión `.qtorres` genérica se reemplaza por extensiones con significado semántico (`.qvi`, `.qproj`, etc.)
 
-**MVP:** Solo `.qvi` y `.qproj`. Los demás tipos se añaden en fases posteriores.
+**Implementación inicial:** Solo `.qvi` y `.qproj`. Los demás tipos se añaden en fases posteriores.
 
 ---
 
@@ -188,7 +188,6 @@ view layout [
 - El compilador debe generar Red/View, no solo código imperativo
 - Los controles del Front Panel se convierten en `field` y `button` de Red/View
 - Los indicadores se convierten en `text` reactivos que se actualizan al pulsar Run
-- Esta es la diferencia más significativa respecto al MVP actual
 
 ---
 
@@ -480,7 +479,7 @@ meta: [
 
 **Decisión:** QTorres se diseña para que agentes de IA externos puedan generar ficheros del ecosistema QTorres a partir de descripciones en lenguaje natural o especificaciones técnicas. Esto se desarrolla en dos niveles de madurez:
 
-### Nivel 1 — Vibe coding (MVP)
+### Nivel 1 — Vibe coding
 
 Un agente de IA externo (Claude Code, Kilo Code, Ollama, o cualquier herramienta) genera ficheros `.qvi` individuales a partir de una descripción en lenguaje natural. El agente solo trabaja con la sección `qvi-diagram` — el compilador de QTorres genera el código ejecutable.
 

--- a/docs/red-issues.md
+++ b/docs/red-issues.md
@@ -179,17 +179,70 @@ Corrección aplicada: Añadido `Needs: 'View` al header.
 
 ---
 
+---
+
+## 0021 — BUG · `src/ui/diagram/canvas.red:339–341` ✅ RESUELTO
+
+**`remove find model/wires model/selected-wire` falla si `find` devuelve `none`**
+
+Corrección aplicada:
+```red
+if found: find model/wires model/selected-wire [
+    remove found
+]
+```
+
+---
+
+## 0022 — BUG · `src/compiler/compiler.red:228` ✅ RESUELTO
+
+**`to set-path!` es sintaxis inválida — datatype correcto es `path!`**
+
+Corrección aplicada:
+```red
+append run-body compose [(to path! reduce [face-sym 'text]) form (src-var)]
+```
+
+---
+
+## 0023 — BUG · `src/graph/model.red:84–112` ✅ RESUELTO
+
+**`sync-name-counters` usa `repeat i` con acceso `parts/:i` — frágil para types con `_` embedded**
+
+Corrección aplicada: Cambiado `keep parts/:i` por `append type-str parts/:i` con cadena mutable.
+
+---
+
+## 0024 — BUG · `src/io/file-io.red:140–151` ✅ RESUELTO
+
+**`load-vi` busca `from-port`/`to-port` pero los ejemplos usan formato corto `port`**
+
+Los ejemplos `.qvi` usan: `wire [from: 1 port: 'out to: 3 port: 'a]`
+`load-vi` buscaba: `wire [from: 1 from-port: 'out to: 3 to-port: 'a]`
+
+Corrección aplicada: Soporta ambos formatos con `any [select wire-spec 'from-port select wire-spec 'port]`.
+
+---
+
+## 0025 — WARN · `src/ui/diagram/canvas.red:173–178` ✅ RESUELTO
+
+**`switch` para `type-label` sin casos para `mul`, `div`, `display`, `subvi`**
+
+Corrección aplicada: Añadidos los casos `mul ["MUL *"]`, `div ["DIV /"]`, `display ["DISP"]`, `subvi ["SUBVI"]` y `default`.
+
+---
+
 ## Resumen
 
 | Fichero | BUG | WARN | STYLE | Total |
 |---------|-----|------|-------|-------|
-| `src/graph/model.red` | 1 | 4 | 0 | 5 |
-| `src/ui/diagram/canvas.red` | 2 | 2 | 2 | 6 |
-| `src/compiler/compiler.red` | 1 | 1 | — | 2 |
+| `src/graph/model.red` | 2 | 4 | 0 | 6 |
+| `src/ui/diagram/canvas.red` | 2 | 3 | 2 | 7 |
+| `src/compiler/compiler.red` | 2 | 1 | — | 3 |
 | `src/graph/blocks.red` | 1 | — | — | 1 |
-| `src/io/file-io.red` | — | 1 | 1 | 2 |
+| `src/io/file-io.red` | 1 | 1 | 1 | 3 |
 | `src/runner/runner.red` | — | 1 | — | 1 |
 | `src/qtorres.red` | — | — | 1 | 1 |
-| **Total** | **5** | **9** | **4** | **18** |
+| **Total** | **8** | **10** | **4** | **22** |
 
 Todos los issues resueltos. ✅

--- a/docs/retos.md
+++ b/docs/retos.md
@@ -20,7 +20,7 @@
 
 **Riesgo:** Red/View + Draw no tienen primitivas de alto nivel para editores gráficos (hit testing, z-order, layout automático de wires). Hay que construirlas.
 
-**Impacto:** Construir el canvas puede consumir la mayor parte del esfuerzo del MVP.
+**Impacto:** Construir el canvas puede consumir la mayor parte del esfuerzo en Fase 1.
 
 **Mitigación:**
 - Spike técnico (Fase 0) antes de cualquier otra cosa
@@ -36,7 +36,7 @@
 **Impacto:** Un diagrama ilegible hace que QTorres sea inutilizable incluso si todo funciona.
 
 **Mitigación:**
-- MVP con wires rectos (línea directa entre puertos)
+- Fase 1 con wires rectos (línea directa entre puertos)
 - Routing ortogonal (estilo LabVIEW) como mejora posterior
 - Estudiar algoritmos existentes de routing en editores de grafos
 
@@ -47,7 +47,7 @@
 **Impacto:** Bucles y condicionales pueden requerir un rediseño del compilador si no se anticipan.
 
 **Mitigación:**
-- El MVP solo tiene aritmética lineal (sort topológico trivial)
+- Fase 1 solo tiene aritmética lineal (sort topológico trivial)
 - Diseñar la representación intermedia del grafo pensando en que habrá estructuras de control
 - Estudiar cómo LabVIEW internamente compila sus diagramas
 
@@ -58,14 +58,14 @@
 **Impacto:** Usabilidad baja → abandonan QTorres.
 
 **Mitigación:**
-- Definir desde el MVP qué errores se detectan: tipos incompatibles, ciclos, puertos sin conectar
+- Definir desde el inicio qué errores se detectan: tipos incompatibles, ciclos, puertos sin conectar
 - Mostrar errores visualmente en el diagrama (wire rojo, bloque resaltado), no solo en texto
 
 ## Riesgo bajo (pero a tener en cuenta)
 
 ### Tipado de wires
 
-Los wires en LabVIEW tienen tipo (numérico, string, booleano, cluster, array). El color del wire indica el tipo. Esto hay que diseñarlo desde el inicio aunque el MVP solo use numéricos, para no tener que refactorizar la estructura de datos del grafo.
+Los wires en LabVIEW tienen tipo (numérico, string, booleano, cluster, array). El color del wire indica el tipo. Esto hay que diseñarlo desde el inicio aunque en Fase 1 solo use numéricos, para no tener que refactorizar la estructura de datos del grafo.
 
 ### Rendimiento del canvas
 
@@ -73,7 +73,7 @@ Con pocos bloques no hay problema. Con 50+ bloques y wires, el redibujo del canv
 
 ### Undo/Redo
 
-No está en el MVP pero es imprescindible para cualquier editor. La arquitectura del modelo de datos debe contemplarlo (command pattern o similar) desde el diseño.
+No está en Fase 1 pero es imprescindible para cualquier editor. La arquitectura del modelo de datos debe contemplarlo (command pattern o similar) desde el diseño.
 
 ## Preguntas abiertas
 

--- a/docs/tipos-de-fichero.md
+++ b/docs/tipos-de-fichero.md
@@ -370,6 +370,6 @@ qctl [
 ]
 ```
 
-## MVP
+## Tipos implementados
 
-El MVP solo implementa `.qvi` y `.qproj`. Los demás tipos (`.qlib`, `.qprim`, `.qctl`) se añaden en fases posteriores, pero el formato está definido desde el inicio para que la estructura sea consistente.
+QTorres implementa `.qvi` y `.qproj`. Los demás tipos (`.qlib`, `.qprim`, `.qctl`) se añaden en fases posteriores.

--- a/src/compiler/compiler.red
+++ b/src/compiler/compiler.red
@@ -225,7 +225,7 @@ compile-diagram: func [
                         foreach src diagram/nodes [
                             if src/id = w/from-node [
                                 src-var: port-var src to-word w/from-port
-                                append run-body compose [(to set-path! reduce [face-sym 'text]) form (src-var)]
+                                append run-body compose [(to path! reduce [face-sym 'text]) form (src-var)]
                             ]
                         ]
                     ]

--- a/src/graph/model.red
+++ b/src/graph/model.red
@@ -89,16 +89,14 @@ sync-name-counters: func [
     reset-name-counters
     foreach nm names [
         if string? nm [
-            ; Extraer tipo y número de "tipo_N"
             parts: split nm "_"
             if (length? parts) >= 2 [
-                type-str: rejoin collect [
-                    repeat i ((length? parts) - 1) [
-                        if i > 1 [keep "_"]
-                        keep parts/:i
-                    ]
+                type-str: copy ""
+                repeat i ((length? parts) - 1) [
+                    if i > 1 [append type-str "_"]
+                    append type-str parts/:i
                 ]
-                num-str: last parts
+                num-str: parts/(length? parts)
                 num: attempt [to-integer num-str]
                 if num [
                     cur: any [select name-counters to-word type-str  0]

--- a/src/io/file-io.red
+++ b/src/io/file-io.red
@@ -140,9 +140,9 @@ load-vi: func [
                 'wire set wire-spec block! (
                     append d/wires make-wire compose [
                         from: (select wire-spec 'from)
-                        from-port: (select wire-spec 'from-port)
+                        from-port: (any [select wire-spec 'from-port  select wire-spec 'port])
                         to: (select wire-spec 'to)
-                        to-port: (select wire-spec 'to-port)
+                        to-port: (any [select wire-spec 'to-port  select wire-spec 'port])
                     ]
                 )
                 | skip

--- a/src/ui/diagram/canvas.red
+++ b/src/ui/diagram/canvas.red
@@ -175,6 +175,11 @@ render-bd: func [model /local cmds src-node dst-node out-xy in-xy mid-x wire-col
             indicator ["IND"]
             add       ["ADD +"]
             sub       ["SUB -"]
+            mul       ["MUL *"]
+            div       ["DIV /"]
+            display   ["DISP"]
+            subvi     ["SUBVI"]
+            default   [uppercase form node/type]
         ]
         either all [node/label  object? node/label  node/label/visible] [
             append cmds compose [
@@ -337,7 +342,9 @@ canvas-delete-selected: func [canvas /local model node-id] [
     model: canvas/extra
     case [
         model/selected-wire [
-            remove find model/wires model/selected-wire
+            if found: find model/wires model/selected-wire [
+                remove found
+            ]
             model/selected-wire: none
             canvas/draw: render-bd model
         ]


### PR DESCRIPTION
## Summary
- 5 bugs críticos detectados en análisis estático del código Red corregidos
- Eliminadas todas las referencias a MVP de la documentación (CLAUDE.md, CONTRIBUTING.md, QTorres.md, docs/)

## Bugs corregidos

| # | Fichero | Bug |
|---|---------|-----|
| 0021 | `canvas.red:339` | `remove find` sin guardia de `none` |
| 0022 | `compiler.red:228` | `to set-path!` → `to path!` (tipo inválido) |
| 0023 | `model.red:84-112` | `sync-name-counters` frágil con `repeat` + acceso por índice |
| 0024 | `file-io.red:140` | `load-vi` no soportaba formato corto `port` de los ejemplos `.qvi` |
| 0025 | `canvas.red:173` | `switch type-label` sin `mul`, `div`, `display`, `subvi` |

## Documentación
- `docs/red-issues.md` actualizado con issues 0021-0025
- Todas las referencias a `MVP/QTorres-mvp.red` eliminadas del proyecto (el archivo no existe en el repo)