### PR TITLE
fix: guard condition en canvas.red — system/script/path devuelve none

### DIFF
--- a/src/ui/diagram/canvas.red
+++ b/src/ui/diagram/canvas.red
@@ -544,7 +544,7 @@ repeat i 15 [
     ]
 ]
 
-if system/options/script = system/script/path [
+if find form system/options/script "canvas.red" [
     canvas: render-diagram demo-model 880 490
     canvas/offset: 10x38
 


### PR DESCRIPTION
## Problema

`system/script/path` devuelve `none` en la versión actual de Red, lo que hacía que la condición guard del demo standalone:

```red
if system/options/script = system/script/path [
```

siempre evaluase a `false`. Al ejecutar `./red-view ./src/ui/diagram/canvas.red`, el script terminaba sin abrir ventana (exit code 255, sin error visible).

## Solución

Reemplazar la comparación por:

```red
if find form system/options/script "canvas.red" [
```

Esto comprueba si el script que se está ejecutando contiene "canvas.red" en su ruta, independientemente de los valores de `system/script/path`.

## Verificación

- `./red-view ./src/ui/diagram/canvas.red` abre correctamente la ventana del canvas con los 20 nodos y 15 wires del stress test.