### PR TITLE
feat(#10): tipo string completo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,46 +158,38 @@ qvi-diagram: [
 5. Cerrar el Issue cuando esté completo (`gh issue close N --repo anlaco/QTorres`)
 
 ### Orden de los Issues (backlog)
-Trabajar siempre en orden de Fase. No empezar Fase 1 sin completar Fase 0.
+Trabajar siempre en orden de Fase. No empezar una fase sin completar la anterior.
 
-**Fase 0 — Spike técnico ✅ COMPLETADA (Issues #1-#4 CERRADOS)**
+**Fase 0 — Spike técnico ✅ COMPLETADA**
 
-**Fase 1 — Beta funcional (Issues #5-#13, #20-#22, #26):**
-- #20 Borrar wire/nodo con Delete ← EMPEZAR AQUÍ (edición básica)
-- #21 Renombrar nodo con doble clic
-- #22 Identidad visual: diseño de bloques moderno
-- #5 Procesador dialecto block-def
-- #6 Topological-sort
-- #7 bind-emit
-- #8 Compilador genera Red/View (DT-009)
-- #9 save-vi y load-vi
-- #10 Runner en memoria
-- #11 Canvas modular
-- #12 Front Panel modular
-- #13 Conectar módulos en qtorres.red
-- #26 ⚠️ IMPORTANTE: .qvi generado — set-path bug + formato legible (bug funcional standalone + coherencia)
+**Fase 1 — Beta funcional ✅ COMPLETADA**
+- Issues cerrados: #6 (renombrar nodo), #7 (Front Panel), #8 (conectar módulos), #26 (.qvi formato)
+- Identidad visual: especificación en `docs/visual-spec.md` (documento vivo, se aplica progresivamente)
 
-**Fase 2 — Tipos de datos y estructuras (Issues #15-#17, #23-#25, #27-#28):**
-- #23 Tipo booleano
-- #24 Tipo string
-- #25 Array 1D
-- Cluster (issue pendiente de crear)
-- #27 Waveform chart y graph
-- #28 Front Panel standalone visualmente fiel al canvas (requiere #12)
-- #15 While Loop
-- #16 For Loop
-- #17 Case Structure
+**Fase 2 — Tipos de datos y estructuras (orden decidido 2026-03-22):**
+1. ~~#9 Tipo booleano~~ ✅
+2. #10 Tipo string ← SIGUIENTE
+3. #14 While Loop
+4. #15 For Loop
+5. #11 Array 1D
+6. #16 Case Structure
+7. #12 Cluster
+8. #13 Waveform chart y graph
+9. #28 Front Panel standalone (puede esperar)
 
-**Fase 3 — Sub-VIs y extensibilidad (Issues #18-#19):**
-- #18 Sub-VI con connector pane
-- #19 Librería .qlib
+Estrategia QA: tests con cada feature nueva, no sesión QA dedicada.
+Spec visual: cada tipo implementa su aspecto según `docs/visual-spec.md`.
 
-**Fase 4 — Hardware (issues pendientes de crear):**
-- SCPI sobre TCP/IP (Keysight por red)
-- SCPI sobre USB/USBTMC (Keysight por USB)
-- Puerto serie RS-232/RS-485 (Arduino, ESP32)
-- TCP/IP genérico (Modbus TCP, protocolos propios)
-- DAQ analógico (comedi/libcomedi)
+**Fase 3 — Sub-VIs y extensibilidad:**
+- #17 Sub-VI con connector pane
+- #18 Librería .qlib
+
+**Fase 4 — Hardware:**
+- #19 SCPI sobre TCP/IP (Keysight por red)
+- #20 SCPI sobre USB/USBTMC (Keysight por USB)
+- #21 Puerto serie RS-232/RS-485 (Arduino, ESP32)
+- #22 TCP/IP genérico (Modbus TCP, protocolos propios)
+- #23 DAQ analógico (comedi/libcomedi)
 
 ## Comandos útiles
 
@@ -238,3 +230,4 @@ Cubre sintaxis core, View, Draw, VID, Parse, patrones idiomáticos y gotchas.
 - Riesgos conocidos: `docs/retos.md`
 - Bugs GTK Linux: `docs/GTK_ISSUES.md`
 - **Comportamiento de LabVIEW:** `docs/labview-comportamiento.md` — **leer antes de tomar decisiones de arquitectura sobre UI, labels y edición de elementos**
+- **Especificación visual:** `docs/visual-spec.md` — **leer antes de implementar cualquier elemento visual** (documento vivo, crece con cada feature)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -69,34 +69,34 @@ Validar que Red/View soporta las primitivas necesarias.
 
 ---
 
-## Fase 1 — Beta funcional
+## Fase 1 — Beta funcional ✅ COMPLETADA
 
 Ciclo completo: dibujar → compilar → ejecutar → ver resultado.
 
 ### Edición del diagrama
-- [ ] Canvas modular (refactor de canvas.red a src/ui/diagram/)
-- [ ] Borrar wire/nodo con tecla Delete (#20)
-- [ ] Renombrar nodo con doble clic (#21)
-- [ ] Identidad visual: diseño de bloques moderno, customizable (#22)
+- [x] Canvas modular (refactor de canvas.red a src/ui/diagram/)
+- [x] Borrar wire/nodo con tecla Delete
+- [x] Renombrar nodo con doble clic (#6)
+- [x] Identidad visual: especificación definida en [`docs/visual-spec.md`](visual-spec.md) (documento vivo, se implementa progresivamente)
 
 ### Motor de compilación
-- [ ] Procesador dialecto `block-def` (#5)
-- [ ] Topological sort del grafo (#6)
-- [ ] `bind-emit`: sustituye nombres de puerto por variables (#7)
-- [ ] Compilador genera Red/View completo (DT-009) (#8)
-- [ ] Guardar/cargar .qvi: `save-vi` y `load-vi` (#9)
-- [ ] Runner en memoria (ejecuta sin generar fichero) (#10) — ver [REVISAR] en `docs/arquitectura.md`
-- [ ] Ejecución continua en loop (Etapa 2)
+- [x] Procesador dialecto `block-def`
+- [x] Topological sort del grafo
+- [x] `bind-emit`: sustituye nombres de puerto por variables
+- [x] Compilador genera Red/View completo (DT-009) (#8)
+- [x] Guardar/cargar .qvi: `save-vi` y `load-vi`
+- [x] Runner en memoria (ejecuta sin generar fichero)
+- [x] .qvi multi-línea + set-path indicadores + bugs serialize/load (#26)
 
 ### Bloques primitivos de Fase 1
-- Constante numérica, Suma, Resta, Multiplicación, División
-- Display numérico
-- Controles e indicadores numéricos en Front Panel
+- [x] Constante numérica, Suma, Resta, Multiplicación, División
+- [x] Display numérico
+- [x] Controles e indicadores numéricos en Front Panel
 
 ### Front Panel modular
-- [ ] Panel con controles e indicadores arrastrables (#12)
-- [ ] Botón Run visible en el panel
-- [ ] Conectar módulos en `qtorres.red` (#13)
+- [x] Panel con controles e indicadores arrastrables (#7)
+- [x] Botón Run visible en el panel
+- [x] Conectar módulos en `qtorres.red` (#8)
 
 ### Qué genera el compilador (decisión DT-009)
 
@@ -116,25 +116,42 @@ Los controles de entrada se convierten en `field` editables. Los indicadores de 
 
 ## Fase 2 — Tipos de datos y estructuras de control
 
-### Tipos de datos esenciales
-- [ ] Tipo booleano: wire azul oscuro, control LED, indicador LED (#23)
-- [ ] Tipo string: wire rosa, control field, indicador text (#24)
-- [ ] Array 1D: wire con borde doble, representación en Front Panel (#25)
-- [ ] Cluster: wire marrón, editor de campos (#26)
+> **Estrategia QA:** cada feature nueva llega con sus tests. Al tocar un módulo existente, se aprovecha para cubrir tests pendientes de ese módulo. No hay sesión QA dedicada.
+>
+> **Especificación visual:** cada tipo y estructura implementa su aspecto según [`docs/visual-spec.md`](visual-spec.md).
 
-### Visualización
-- [ ] Waveform chart y graph en Front Panel (#27)
-- [ ] Wires con color según tipo (numérico naranja, booleano azul, string rosa)
-- [ ] Error de tipo al conectar wires incompatibles (visual en el wire)
+### Orden de implementación (decidido 2026-03-22)
 
-### Estructuras de control
-- [ ] While Loop con terminal de condición (#15)
-- [ ] For Loop con terminal N e índice (#16)
-- [ ] Case Structure con selector y múltiples frames (#17)
+**Bloque 1 — Tipos básicos**
+1. [x] Tipo booleano: wire verde, control LED, indicador LED (#9) ✅
+2. [ ] Tipo string: wire rosa con patrón característico, control field, indicador text (#10)
+
+**Bloque 2 — Estructuras de control**
+3. [ ] While Loop con terminal de condición (#14)
+4. [ ] For Loop con terminal N e índice (#15)
+
+**Bloque 3 — Datos compuestos**
+5. [ ] Array 1D: wire grueso con borde doble, representación en Front Panel (#11)
+6. [ ] Case Structure con selector y múltiples frames (#16)
+
+**Bloque 4 — Tipos avanzados**
+7. [ ] Cluster: wire marrón, editor de campos (#12)
+8. [ ] Waveform chart y graph en Front Panel (#13)
+
+### Visualización (progresivo con cada tipo)
+- [x] Wires con color según tipo (numérico naranja, booleano verde)
+- [ ] Wires con patrón según tipo (string rayado/segmentado)
+- [ ] Wires con grosor según estructura (escalar fino, array grueso)
+- [ ] Wire roto (X roja) al conectar tipos incompatibles
+- [ ] Regla: una entrada solo acepta un wire (actualmente permite múltiples)
+- [ ] Coercion dots — cuando existan subtipos numéricos (Fase 2 tardía o Fase 3)
 
 ### Calidad de edición
 - [ ] Undo/Redo (historial de acciones)
 - [ ] Validación: detectar ciclos, tipos incompatibles, puertos sin conectar
+
+### Front Panel
+- [ ] Front Panel standalone visualmente fiel al canvas (#28) — puede esperar
 
 ---
 
@@ -183,8 +200,9 @@ Esta fase es esencial para el público objetivo (mismo que LabVIEW: ingeniería 
 | Hito | Descripción | Fase |
 |------|------------|------|
 | Canvas vivo | Bloques arrastrables con wires dibujados | 0 ✅ |
-| Primera compilación | .qvi guardado se ejecuta con Red directamente | 1 |
-| Primer programa útil | Aritmética con Front Panel funcional | 1 |
+| Primera compilación | .qvi guardado se ejecuta con Red directamente | 1 ✅ |
+| Primer programa útil | Aritmética con Front Panel funcional | 1 ✅ |
+| Tipo booleano | Wire verde, LED control/indicator | 2 ✅ |
 | Tipos completos | Boolean, string, array, cluster en wires | 2 |
 | Estructuras de control | Bucles y condicionales en el diagrama | 2 |
 | Sub-VIs | VIs reutilizables como bloques con connector | 3 |
@@ -197,7 +215,7 @@ Esta fase es esencial para el público objetivo (mismo que LabVIEW: ingeniería 
 
 Trabajar siempre Issues en orden de Fase. No empezar una fase sin completar la anterior.
 
-**Próximo:** Fase 1 — empezar por Issue #20 (borrar wire/nodo) o Issue #22 (identidad visual, decide el look antes de construir más UI).
+**Próximo:** Fase 2 — Issue #10 (tipo string).
 
 ---
 

--- a/docs/visual-spec.md
+++ b/docs/visual-spec.md
@@ -1,0 +1,242 @@
+# Especificación visual — QTorres
+
+Documento vivo que define la identidad visual de QTorres.
+Principio rector: **igual que LabVIEW en forma, tamaños y comportamiento; no en estilos.**
+Un programador de LabVIEW debe sentirse cómodo desde el primer momento.
+
+Este documento crecerá conforme se implementen nuevos tipos y funcionalidades.
+
+---
+
+## 1. Canvas y navegación
+
+### 1.1 Sin zoom
+
+QTorres no implementa zoom, igual que LabVIEW. Esto es una decisión de diseño
+deliberada para evitar que los diagramas crezcan al infinito.
+
+### 1.2 Scrollbars dinámicas
+
+Tanto el Block Diagram (BD) como el Front Panel (FP) tienen scrollbars que se
+ajustan dinámicamente al contenido:
+- El diagrama vive en un espacio "infinito"
+- Las scrollbars reflejan la posición de los componentes respecto al espacio total
+- Si un componente se acerca a un borde, la scrollbar se hace más pequeña
+  porque el espacio útil crece
+- El diagrama se centra dentro del rango de las scrollbars
+
+### 1.3 Grid
+
+- El movimiento con flechas del teclado es pixel a pixel (1px)
+- El movimiento con Shift + flechas es un salto mayor (por definir: 8px o 12px)
+- No hay grid visible por defecto, pero los elementos se pueden alinear manualmente
+
+---
+
+## 2. Bloques: controles e indicadores en BD
+
+### 2.1 Dos modos de visualización: "View as Icon"
+
+Cada control e indicador tiene una propiedad individual `view-as-icon` (true/false).
+No es global del diagrama — se puede configurar por elemento.
+
+**Icon ON (view-as-icon: true):**
+- Cuadrado con icono visual del tipo de control/indicador
+- Borde del color del tipo de dato
+- Abreviatura del tipo centrada abajo (DBL, TF, STR...)
+- Tamaño mayor, más visual
+
+**Icon OFF (view-as-icon: false):**
+- Rectángulo compacto
+- Color de fondo del tipo de dato
+- Abreviatura del tipo como texto (DBL, TF, STR...)
+- Tamaño reducido, ideal para diagramas densos
+
+### 2.2 Distinción control vs indicador
+
+- **Control** (entrada) → borde fino
+- **Indicador** (salida) → borde grueso
+
+Esta convención visual es consistente con LabVIEW y se aplica tanto en el
+connector pane como en la representación en BD.
+
+### 2.3 Abreviaturas por tipo
+
+| Tipo       | Abreviatura | Color      |
+|------------|-------------|------------|
+| Numeric (float/double) | DBL | Naranja |
+| Boolean    | TF          | Verde      |
+| String     | STR         | Rosa       |
+| Integer    | I32 / I16 / etc. | Azul  |
+| Cluster    | (pendiente) | Marrón     |
+
+*Nota: la tabla se expandirá conforme se implementen nuevos tipos.*
+
+---
+
+## 3. Bloques: funciones primitivas
+
+### 3.1 Formas propias
+
+Las funciones primitivas (Add, Subtract, And, Or, Not...) **no usan el patrón
+genérico 4224**. Cada una tiene su propia forma con terminales en posiciones
+específicas.
+
+Ejemplo: **Add** es un triángulo rotado 90°. La punta es la salida (result),
+la base tiene las dos entradas (a, b) distribuidas verticalmente.
+
+*Las formas específicas de cada primitiva se definirán al implementarla.*
+
+### 3.2 SubVIs: patrón 4224
+
+Los SubVIs usan el connector pane con el patrón **4-2-2-4** como punto de
+partida:
+- 4 terminales arriba
+- 2 terminales a la izquierda (entradas)
+- 2 terminales a la derecha (salidas)
+- 4 terminales abajo
+
+Los terminales se **reparten el espacio equitativamente** dentro del bloque.
+El connector pane ocupa todo el bloque — no hay espacio muerto.
+
+Si se necesitan más terminales, se considerarán patrones adicionales.
+
+### 3.3 SubVIs: view-as-icon
+
+Los SubVIs también soportan `view-as-icon`:
+
+**Icon ON:** Cuadrado con el icono del VI y borde del color del tipo.
+
+**Icon OFF:** Rectángulo compacto. Muestra flechas de entrada (izquierda) y
+salida (derecha) con el color del tipo de dato de cada terminal. En la parte
+inferior tiene un control de expansión (flecha) que al arrastrar hacia abajo
+despliega los terminales con nombre, uno a uno (similar a un Property Node en
+LabVIEW). Al desplegar un terminal, su flecha correspondiente desaparece.
+
+---
+
+## 4. Wires
+
+### 4.1 Codificación visual por tipo
+
+Los wires codifican el tipo de dato mediante **tres canales visuales**:
+
+| Canal   | Qué indica   |
+|---------|--------------|
+| Color   | Familia de tipo (numérico, booleano, string...) |
+| Grosor  | Estructura (escalar, array 1D, array 2D...) |
+| Patrón  | Refuerzo de estructura + casos especiales |
+
+### 4.2 Tabla de wires — tipos básicos
+
+| Tipo     | Color    | Grosor | Patrón   |
+|----------|----------|--------|----------|
+| Numeric (DBL) | Naranja | Fino (1px) | Sólido |
+| Boolean  | Verde    | Fino (1px) | Sólido |
+| String   | Rosa     | Fino (1px) | Patrón característico (rayado/segmentado) |
+| Integer  | Azul     | Fino (1px) | Sólido |
+
+*Arrays, clusters y tipos compuestos se definirán al implementarse en Fase 2.*
+
+### 4.3 Wires de array (futuro)
+
+Cuando se implementen arrays:
+- **Array 1D** → grosor grueso + borde doble
+- **Array 2D** → aún más grueso
+
+El color sigue siendo el del tipo base (array de DBL = naranja grueso).
+
+### 4.4 Color de wire por tipo (referencia rápida)
+
+- Naranja → numérico float/double
+- Azul → entero
+- Verde → booleano
+- Rosa → string
+- Marrón → cluster (futuro)
+
+---
+
+## 5. Reglas de conexión de wires
+
+### 5.1 Tipos incompatibles → wire roto
+
+Cuando se conecta un wire entre terminales de tipos incompatibles:
+- El wire **se dibuja** (no se impide el gesto)
+- Se muestra una **X roja** en el punto medio del wire
+- El VI no puede ejecutarse mientras haya wires rotos
+- Al pasar el ratón por el wire roto: tooltip con el motivo
+  ("Type mismatch: expected DBL, got TF")
+
+*Nota: el comportamiento actual de QTorres impide dibujar el wire. Hay que
+cambiar a este modelo donde se dibuja pero se marca como roto.*
+
+### 5.2 Una entrada, un solo wire
+
+- Una **entrada** (input terminal) solo acepta **un wire**
+- Una **salida** (output terminal) puede tener **múltiples wires**
+  (branch / bifurcación)
+- Intentar conectar un segundo wire a una entrada que ya tiene uno
+  es un error → wire roto o rechazo
+
+*Nota: el comportamiento actual de QTorres permite múltiples wires a una
+entrada. Hay que corregir esto.*
+
+### 5.3 Coercion dots (futuro — Fase 2 tardía o Fase 3)
+
+Cuando se conectan tipos compatibles pero no idénticos (ej: Integer a Double):
+- La conexión funciona (no es wire roto)
+- Aparece un **punto rojo** (coercion dot) en el terminal donde ocurre la
+  conversión implícita
+- Indica posible pérdida de precisión o coste de rendimiento
+- Se implementará cuando existan subtipos numéricos (integer vs float vs double)
+
+---
+
+## 6. Paleta de funciones y controles
+
+### 6.1 Apertura con clic derecho
+
+- **Clic derecho en BD** → abre paleta de funciones
+- **Clic derecho en FP** → abre paleta de controles
+
+### 6.2 Estructura jerárquica
+
+La paleta es un menú con carpetas organizadas por categoría:
+- Nivel 1: Categorías (Structures, Numeric, Array, Boolean, String...)
+- Nivel 2: Subcategorías o primitivas directamente
+- Puede haber más niveles de profundidad
+
+### 6.3 Comportamiento de navegación
+
+- Las subcarpetas se abren al **dejar el ratón sobre el icono** (hover con delay)
+- Cada subpaleta tiene un **botón de pin** para dejarla fija en pantalla
+- Una vez fijada, la paleta permanece abierta como ventana flotante
+
+*Nota: este es un comportamiento complejo. Se implementará progresivamente,
+empezando por una paleta básica y añadiendo hover + pin más adelante.*
+
+---
+
+## 7. Pendiente de definir
+
+Elementos visuales que sabemos que existen en LabVIEW pero que aún no hemos
+especificado. Se documentarán conforme sea necesario:
+
+- Icono del botón Run roto (cuando hay wires rotos o errores)
+- Breakpoints y ejecución paso a paso (highlight execution)
+- Error clusters y su representación visual
+- Decoraciones del diagrama (free labels, comentarios, flat sequence)
+- Colores de selección y highlight
+- Tipografía y tamaños de texto
+- Property Nodes y su formato expandible
+- Representaciones específicas de cada primitiva (formas de Add, Sub, Mul, etc.)
+- Cluster: wire marrón + patrón trenzado + editor de campos
+- Typedef: representación visual diferenciada
+
+---
+
+## Historial
+
+| Fecha      | Cambio |
+|------------|--------|
+| 2026-03-22 | Creación inicial — reunión de planificación |

--- a/src/compiler/compiler.red
+++ b/src/compiler/compiler.red
@@ -177,6 +177,15 @@ node-boolean-input?: func [node /local bdef] [
     false
 ]
 
+; Devuelve true si el primer output del bloque es de tipo string.
+node-string-input?: func [node /local bdef] [
+    bdef: find-block to-word node/type
+    if all [bdef  not empty? bdef/outputs] [
+        return bdef/outputs/1/type = 'string
+    ]
+    false
+]
+
 ; ══════════════════════════════════════════════════
 ; COMPILE-BODY
 ; ══════════════════════════════════════════════════
@@ -226,10 +235,16 @@ compile-diagram: func [
         case [
             bdef/category = 'input [
                 face-sym: to-word rejoin ["f_" node/id]
-                either node-boolean-input? node [
-                    append run-body compose [(to-set-word port-var node 'result) (to-path reduce [face-sym 'data])]
-                ][
-                    append run-body compose [(to-set-word port-var node 'result) to-float (to-path reduce [face-sym 'text])]
+                case [
+                    node-boolean-input? node [
+                        append run-body compose [(to-set-word port-var node 'result) (to-path reduce [face-sym 'data])]
+                    ]
+                    node-string-input? node [
+                        append run-body compose [(to-set-word port-var node 'result) (to-path reduce [face-sym 'text])]
+                    ]
+                    true [
+                        append run-body compose [(to-set-word port-var node 'result) to-float (to-path reduce [face-sym 'text])]
+                    ]
                 ]
             ]
             bdef/category = 'output [
@@ -263,7 +278,11 @@ compile-diagram: func [
             face-n: to-word rejoin ["f_" node/id]
             ; any [none false] = none en Red (false es falsy) → usar either/none? explícito
             cfg-val: either none? select node/config 'default [
-                either node-boolean-input? node [false] [0.0]
+                case [
+                    node-boolean-input? node [false]
+                    node-string-input?  node [""]
+                    true                     [0.0]
+                ]
             ][
                 select node/config 'default
             ]
@@ -272,14 +291,22 @@ compile-diagram: func [
             ; UI layout usa label/text (display) para textos visibles (DT-024)
             append ui-layout node-label
             append ui-layout to-set-word face-n
-            either node-boolean-input? node [
-                ; Control booleano: check face, lee face/data (logic!)
-                append ui-layout 'check
-                append ui-layout node-label
-                append ui-layout cfg-val
-            ][
-                append ui-layout 'field
-                append ui-layout form cfg-val
+            case [
+                node-boolean-input? node [
+                    ; Control booleano: check face, lee face/data (logic!)
+                    append ui-layout 'check
+                    append ui-layout node-label
+                    append ui-layout cfg-val
+                ]
+                node-string-input? node [
+                    ; Control string: field editable, lee face/text directamente
+                    append ui-layout 'field
+                    append ui-layout cfg-val
+                ]
+                true [
+                    append ui-layout 'field
+                    append ui-layout form cfg-val
+                ]
             ]
         ]
     ]

--- a/src/graph/blocks.red
+++ b/src/graph/blocks.red
@@ -140,6 +140,43 @@ block 'indicator 'output [
     in value 'number
 ]
 
+; ── Bloques string ────────────────────────────────────────
+
+block 'str-const 'input [
+    out result 'string
+    config default 'string ""
+    emit [result: default]
+]
+
+block 'str-control 'input [
+    out result 'string
+    config default 'string ""
+    emit [result: default]
+]
+
+block 'str-indicator 'output [
+    in value 'string
+]
+
+block 'concat 'string [
+    in a 'string
+    in b 'string
+    out result 'string
+    emit [result: rejoin [a b]]
+]
+
+block 'str-length 'string [
+    in a 'string
+    out result 'number
+    emit [result: to-float length? a]
+]
+
+block 'to-string 'string [
+    in a 'number
+    out result 'string
+    emit [result: form a]
+]
+
 ; ── Bloques booleanos ─────────────────────────────────────
 
 block 'bool-const 'input [

--- a/src/ui/diagram/canvas.red
+++ b/src/ui/diagram/canvas.red
@@ -15,7 +15,8 @@ col-block-ctrl: 50.100.180
 col-block-ind:  175.125.20
 col-block-op:   55.75.105
 col-wire:       195.95.20
-col-wire-bool:  20.80.160
+col-wire-bool:  20.160.20
+col-wire-str:   220.100.160
 col-wire-sel:   0.160.200
 col-port-in:    50.110.200
 col-port-out:   195.80.25
@@ -63,7 +64,39 @@ port-in-type: func [node port-name /local bdef p] [
 
 ; Devuelve el color de wire para un tipo de dato.
 wire-data-color: func [data-type] [
-    either data-type = 'boolean [col-wire-bool] [col-wire]
+    case [
+        data-type = 'boolean [col-wire-bool]
+        data-type = 'string  [col-wire-str]
+        true                 [col-wire]
+    ]
+]
+
+; Genera comandos Draw para una línea daseada horizontal o vertical.
+; Simula el patrón característico del wire string (visual-spec §4.2).
+draw-dashed-segment: func [p1 [pair!] p2 [pair!] /local cmds dash gap pos end-v horiz] [
+    cmds: copy []
+    dash: 5  gap: 3
+    horiz: p1/y = p2/y
+    either horiz [
+        pos: p1/x  end-v: p2/x
+        if pos > end-v [pos: p2/x  end-v: p1/x]
+        while [pos < end-v] [
+            append cmds compose [
+                line (as-pair pos p1/y) (as-pair (min pos + dash end-v) p1/y)
+            ]
+            pos: pos + dash + gap
+        ]
+    ][
+        pos: p1/y  end-v: p2/y
+        if pos > end-v [pos: p2/y  end-v: p1/y]
+        while [pos < end-v] [
+            append cmds compose [
+                line (as-pair p1/x pos) (as-pair p1/x (min pos + dash end-v))
+            ]
+            pos: pos + dash + gap
+        ]
+    ]
+    cmds
 ]
 
 port-xy: func [node port-name direction /local ports port-index found] [
@@ -98,6 +131,7 @@ make-diagram-model: func [] [
         wire-src:      none
         wire-port:     none
         mouse-pos:     none
+        broken-wire:   none
     ]
 ]
 
@@ -144,9 +178,17 @@ render-bd: func [model /local cmds src-node dst-node out-xy in-xy mid-x wire-col
             mid-x:  to-integer (out-xy/x + in-xy/x) / 2
             wire-dtype: port-out-type src-node wire/from-port
             wire-color: either same? wire model/selected-wire [col-wire-sel] [wire-data-color wire-dtype]
-            append cmds compose [
-                pen (wire-color)  line-width 2
-                line (out-xy) (as-pair mid-x out-xy/y) (as-pair mid-x in-xy/y) (in-xy)
+            either all [wire-dtype = 'string  not same? wire model/selected-wire] [
+                ; Wire string: patrón daseado (visual-spec §4.2)
+                append cmds compose [pen (wire-color)  line-width 2]
+                append cmds draw-dashed-segment out-xy              as-pair mid-x out-xy/y
+                append cmds draw-dashed-segment as-pair mid-x out-xy/y  as-pair mid-x in-xy/y
+                append cmds draw-dashed-segment as-pair mid-x in-xy/y  in-xy
+            ][
+                append cmds compose [
+                    pen (wire-color)  line-width 2
+                    line (out-xy) (as-pair mid-x out-xy/y) (as-pair mid-x in-xy/y) (in-xy)
+                ]
             ]
         ]
     ]
@@ -157,6 +199,20 @@ render-bd: func [model /local cmds src-node dst-node out-xy in-xy mid-x wire-col
         append cmds compose [
             pen col-wire  line-width 2
             line (src-port-xy) (model/mouse-pos)
+        ]
+    ]
+
+    ; 2b) Wire roto — error visual de tipos incompatibles
+    if model/broken-wire [
+        append cmds compose [pen 210.30.30  line-width 2]
+        append cmds draw-dashed-segment model/broken-wire/1 model/broken-wire/2
+        ; Marca X en el punto medio
+        mid: as-pair to-integer (model/broken-wire/1/x + model/broken-wire/2/x) / 2
+                     to-integer (model/broken-wire/1/y + model/broken-wire/2/y) / 2
+        append cmds compose [
+            pen 210.30.30  line-width 2
+            line (as-pair mid/x - 5 mid/y - 5) (as-pair mid/x + 5 mid/y + 5)
+            line (as-pair mid/x + 5 mid/y - 5) (as-pair mid/x - 5 mid/y + 5)
         ]
     ]
 
@@ -175,8 +231,8 @@ render-bd: func [model /local cmds src-node dst-node out-xy in-xy mid-x wire-col
         ]
         ; Texto: tipo + label (DT-022)
         type-label: switch/default node/type [
-            control        ["CTRL"]
-            indicator      ["IND"]
+            control        ["DBL"]
+            indicator      ["DBL"]
             add            ["ADD +"]
             sub            ["SUB -"]
             mul            ["MUL *"]
@@ -185,14 +241,20 @@ render-bd: func [model /local cmds src-node dst-node out-xy in-xy mid-x wire-col
             subvi          ["SUBVI"]
             const          [form any [select node/config 'default  0.0]]
             bool-const     [either any [select node/config 'default  false] ["T"] ["F"]]
-            bool-control   ["B-CTRL"]
-            bool-indicator ["B-IND"]
+            bool-control   ["TF"]
+            bool-indicator ["TF"]
             and-op         ["AND"]
             or-op          ["OR"]
             not-op         ["NOT"]
             gt-op          [">"]
             lt-op          ["<"]
             eq-op          ["="]
+            str-const      [any [select node/config 'default  ""]]
+            str-control    [to-string any [select node/config 'default  "STR"]]
+            str-indicator  ["STR"]
+            concat         ["CONCAT"]
+            str-length     ["LEN"]
+            to-string      ["→STR"]
         ] [uppercase form node/type]
         either all [node/label  object? node/label  node/label/visible] [
             append cmds compose [
@@ -376,6 +438,51 @@ apply-const-value: func [node new-text /local val pos] [
     ]
 ]
 
+; Aplica valor string a un nodo y refresca el canvas.
+; Función auxiliar para evitar set-path con valor literal en compose/deep.
+str-apply-and-refresh: func [nd txt cnv] [
+    apply-str-value nd txt
+    cnv/draw: render-bd cnv/extra
+]
+
+; Abre diálogo para editar el valor de una constante o control string.
+; Usa compose/deep para incrustar node y canvas-face directamente en los handlers,
+; evitando el bug de variables de módulo compartidas cuando dos diálogos están abiertos.
+open-str-edit-dialog: func [node canvas-face /local cur-val] [
+    cur-val: copy any [select node/config 'default  ""]
+    view/no-wait compose/deep [
+        title "Editar string"
+        text "Valor:" return
+        field 200 (cur-val)
+        on-enter [
+            ; face = el field (on-enter se dispara en el field)
+            str-apply-and-refresh (node) copy face/text (canvas-face)
+            unview
+        ]
+        return
+        button "OK" [
+            ; Buscar el field en los panes del panel padre
+            foreach pf face/parent/pane [
+                if pf/type = 'field [
+                    str-apply-and-refresh (node) copy pf/text (canvas-face)
+                    break
+                ]
+            ]
+            unview
+        ]
+        button "Cancelar" [unview]
+    ]
+]
+
+; Actualiza node/config 'default con el nuevo valor string.
+apply-str-value: func [node new-text /local pos] [
+    either pos: find node/config 'default [
+        pos/2: new-text
+    ][
+        append node/config reduce ['default new-text]
+    ]
+]
+
 apply-rename-label: func [node new-text] [
     either empty? new-text [
         if all [node/label  object? node/label] [
@@ -440,6 +547,11 @@ open-palette: func [face x y] [
         button 80 ">"        [palette-add-node 'gt-op]
         button 80 "<"        [palette-add-node 'lt-op]   return
         button 80 "="        [palette-add-node 'eq-op]   return
+        text "String:"  return
+        button 80 "S-Const"  [palette-add-node 'str-const]
+        button 80 "Concat"   [palette-add-node 'concat]         return
+        button 80 "Len"      [palette-add-node 'str-length]
+        button 80 "→STR"     [palette-add-node 'to-string]      return
         button "Cancelar"    [unview]
     ]
 ]
@@ -464,9 +576,9 @@ canvas-delete-selected: func [canvas /local model node-id] [
             remove-each node model/nodes  [node/id = node-id]
             model/selected-node: none
             model/drag-node:     none
-            ; Sync FP: borrar item correspondiente si es control/indicator (o bool-*)
+            ; Sync FP: borrar item correspondiente si es control/indicator (o bool-*/str-*)
             if all [
-                find [control indicator bool-control bool-indicator] node-type
+                find [control indicator bool-control bool-indicator str-control str-indicator] node-type
                 _pref: select model 'panel-ref
             ][
                 remove-each item model/front-panel [item/name = node-name]
@@ -502,22 +614,32 @@ render-diagram: func [model canvas-width canvas-height /local canvas-face] [
                     hit-dir:       hit-result/3
                     either model/wire-src = none [
                         if hit-dir = 'out [
+                            model/broken-wire: none
                             model/wire-src:  hit-nd
                             model/wire-port: hit-port-name
                             model/mouse-pos: event/offset
                             face/draw: render-bd model
                         ]
                     ][
-                        if all [
+                        either all [
                             hit-dir = 'in
                             model/wire-src/id <> hit-nd/id
                             (port-out-type model/wire-src model/wire-port) = (port-in-type hit-nd hit-port-name)
                         ][
+                            model/broken-wire: none
                             append model/wires make-wire compose [
                                 from: (model/wire-src/id)
                                 from-port: (model/wire-port)
                                 to: (hit-nd/id)
                                 to-port: (hit-port-name)
+                            ]
+                        ][
+                            ; Tipos incompatibles: mostrar wire roto en rojo
+                            if all [hit-dir = 'in  model/wire-src/id <> hit-nd/id] [
+                                model/broken-wire: reduce [
+                                    port-xy model/wire-src model/wire-port 'out
+                                    port-xy hit-nd hit-port-name 'in
+                                ]
                             ]
                         ]
                         model/wire-src: none  model/wire-port: none  model/mouse-pos: none
@@ -530,6 +652,7 @@ render-diagram: func [model canvas-width canvas-height /local canvas-face] [
                 hit-ref: hit-node model mouse-x mouse-y
                 if hit-ref [
                     model/wire-src: none  model/wire-port: none  model/mouse-pos: none
+                    model/broken-wire: none
                     model/selected-wire: none
                     model/selected-node: hit-ref
                     model/drag-node: hit-ref
@@ -552,6 +675,7 @@ render-diagram: func [model canvas-width canvas-height /local canvas-face] [
 
                 ; 4) Clic en vacío: cancelar todo
                 model/wire-src: none  model/wire-port: none  model/mouse-pos: none
+                model/broken-wire: none
                 model/drag-node: none  model/selected-wire: none  model/selected-node: none
                 face/draw: render-bd model
             ]
@@ -612,9 +736,13 @@ render-diagram: func [model canvas-width canvas-height /local canvas-face] [
                 mouse-y: event/offset/y
                 node: hit-node model mouse-x mouse-y
                 either node [
-                    ; Nodo existente: const → editar valor; resto → renombrar label
+                    ; Nodo existente: const/str-const/str-control → editar valor; resto → renombrar label
                     if node/type = 'const [
                         open-const-edit-dialog node face
+                        exit
+                    ]
+                    if find [str-const str-control] node/type [
+                        open-str-edit-dialog node face
                         exit
                     ]
                     rename-dialog-node:   node

--- a/src/ui/panel/panel.red
+++ b/src/ui/panel/panel.red
@@ -19,19 +19,21 @@ fp-label-height:     20
 fp-run-button-height: 30
 
 fp-color?: func [item-type] [
-    either find [control bool-control] item-type [fp-control-color] [fp-indicator-color]
+    either find [control bool-control str-control] item-type [fp-control-color] [fp-indicator-color]
 ]
 
 fp-border-color?: func [item-type] [
-    either find [control bool-control] item-type [fp-control-color - 20.20.20] [fp-indicator-color - 20.20.20]
+    either find [control bool-control str-control] item-type [fp-control-color - 20.20.20] [fp-indicator-color - 20.20.20]
 ]
 
 fp-type-label?: func [item-type] [
     case [
-        item-type = 'control        ["CTRL"]
-        item-type = 'indicator      ["IND"]
-        item-type = 'bool-control   ["B-CTRL"]
-        item-type = 'bool-indicator ["B-IND"]
+        item-type = 'control        ["DBL"]
+        item-type = 'indicator      ["DBL"]
+        item-type = 'bool-control   ["TF"]
+        item-type = 'bool-indicator ["TF"]
+        item-type = 'str-control    ["STR"]
+        item-type = 'str-indicator  ["STR"]
         true                        [uppercase form item-type]
     ]
 ]
@@ -43,6 +45,8 @@ fp-default-label: func [item-type] [
     case [
         item-type = 'bool-control   ["Boolean"]
         item-type = 'bool-indicator ["Boolean"]
+        item-type = 'str-control    ["String"]
+        item-type = 'str-indicator  ["String"]
         true                        ["Numeric"]
     ]
 ]
@@ -56,15 +60,38 @@ make-fp-item: func [
     item: make object! [
         id:        any [select spec 'id        0]
         type:      either find [bool-control bool-indicator] raw-type ['control] [raw-type]
-        data-type: either find [bool-control bool-indicator] raw-type ['boolean] ['numeric]
+        data-type: case [
+            find [bool-control bool-indicator] raw-type ['boolean]
+            find [str-control  str-indicator]  raw-type ['string]
+            true                               ['numeric]
+        ]
         name:      any [select spec 'name      ""]
         label:     none
-        default:   any [select spec 'default   either find [bool-control bool-indicator] raw-type [false] [0.0]]
+        default:   case [
+            find [bool-control bool-indicator] raw-type [
+                any [select spec 'default  false]
+            ]
+            find [str-control str-indicator] raw-type [
+                ; copy siempre: las literales "" en Red son constantes compartidas
+                copy any [select spec 'default  ""]
+            ]
+            true [
+                any [select spec 'default  0.0]
+            ]
+        ]
         value:     none
         offset:    any [select spec 'offset    0x0]
     ]
     item/type: raw-type
-    item/value: any [select spec 'value  item/default]
+    ; copy para strings: garantiza que control e indicador son objetos independientes
+    item/value: case [
+        find [str-control str-indicator] raw-type [
+            copy any [select spec 'value  item/default]
+        ]
+        true [
+            any [select spec 'value  item/default]
+        ]
+    ]
 
     ; Name: usar explícito, o generar automáticamente
     item/name: any [select spec 'name  rejoin [form item/type "_" item/id]]
@@ -129,49 +156,86 @@ render-fp-grid: func [w h /local cmds gx gy] [
     cmds
 ]
 
-render-fp-item: func [item selected? /local cmds col border-col type-lbl text-x text-y led-col cx cy] [
+render-fp-item: func [item selected? /local cmds col border-col type-lbl text-x text-y led-col cx cy lbl-text field-y field-h] [
     cmds: copy []
-    col: fp-color? item/type
-    border-col: fp-border-color? item/type
 
-    append cmds compose [
-        pen (border-col)  line-width 1  fill-pen (col)
-        box (as-pair item/offset/x item/offset/y)
-           (as-pair (item/offset/x + fp-item-width) (item/offset/y + fp-item-height)) 4
-    ]
+    either item/data-type = 'string [
+        ; ── String control / indicator: label encima + campo blanco debajo (visual-spec §2) ──
+        lbl-text: either all [item/label  object? item/label  item/label/visible] [
+            any [item/label/text ""]
+        ][""]
+        field-y: item/offset/y + fp-label-height
+        field-h: fp-item-height - fp-label-height
 
-    type-lbl: fp-type-label? item/type
-    text-x: item/offset/x + 8
-    text-y: item/offset/y + 14
-
-    either all [item/label  object? item/label  item/label/visible] [
+        ; Label encima (texto libre, sin fondo)
         append cmds compose [
-            fill-pen 220.230.240
-            text (as-pair text-x (text-y - 8)) (any [item/label/text ""])
-            fill-pen 180.190.200
-            text (as-pair text-x (text-y + 8)) (any [type-lbl ""])
+            fill-pen 30.30.30  pen off
+            text (as-pair (item/offset/x) (item/offset/y + 2)) (lbl-text)
+        ]
+        ; Campo blanco con borde fino (control) o borde doble (indicator, visual-spec §2.2)
+        either item/type = 'str-control [
+            append cmds compose [
+                pen 80.80.80  line-width 1  fill-pen 255.255.255
+                box (as-pair item/offset/x field-y)
+                   (as-pair (item/offset/x + fp-item-width) (field-y + field-h)) 2
+            ]
+        ][
+            ; str-indicator: borde más grueso
+            append cmds compose [
+                pen 80.80.80  line-width 2  fill-pen 245.245.245
+                box (as-pair item/offset/x field-y)
+                   (as-pair (item/offset/x + fp-item-width) (field-y + field-h)) 2
+            ]
+        ]
+        ; Valor dentro del campo
+        append cmds compose [
+            fill-pen 20.20.20  pen off
+            text (as-pair (item/offset/x + 4) (field-y + 4)) (fp-value-text item)
         ]
     ][
-        append cmds compose [
-            fill-pen 220.230.240
-            text (as-pair text-x text-y) (any [type-lbl ""])
-        ]
-    ]
+        ; ── Numeric / Boolean: caja de color con label interior ───────────────────────────
+        col: fp-color? item/type
+        border-col: fp-border-color? item/type
 
-    either item/data-type = 'boolean [
-        ; LED: círculo verde (true) o rojo (false)
-        led-col: either item/value [0.180.0] [180.0.0]
-        cx: item/offset/x + fp-item-width - 20
-        cy: item/offset/y + (fp-item-height / 2)
         append cmds compose [
-            pen (led-col - 40.40.40)  line-width 1  fill-pen (led-col)
-            circle (as-pair cx cy) 10
+            pen (border-col)  line-width 1  fill-pen (col)
+            box (as-pair item/offset/x item/offset/y)
+               (as-pair (item/offset/x + fp-item-width) (item/offset/y + fp-item-height)) 4
         ]
-    ][
-        append cmds compose [
-            fill-pen 255.255.255
-            text (as-pair (item/offset/x + 8) (item/offset/y + fp-item-height - 16))
-                 (fp-value-text item)
+
+        type-lbl: fp-type-label? item/type
+        text-x: item/offset/x + 8
+        text-y: item/offset/y + 14
+
+        either all [item/label  object? item/label  item/label/visible] [
+            append cmds compose [
+                fill-pen 220.230.240
+                text (as-pair text-x (text-y - 8)) (any [item/label/text ""])
+                fill-pen 180.190.200
+                text (as-pair text-x (text-y + 8)) (any [type-lbl ""])
+            ]
+        ][
+            append cmds compose [
+                fill-pen 220.230.240
+                text (as-pair text-x text-y) (any [type-lbl ""])
+            ]
+        ]
+
+        either item/data-type = 'boolean [
+            ; LED: círculo verde (true) o rojo (false)
+            led-col: either item/value [0.180.0] [180.0.0]
+            cx: item/offset/x + fp-item-width - 20
+            cy: item/offset/y + (fp-item-height / 2)
+            append cmds compose [
+                pen (led-col - 40.40.40)  line-width 1  fill-pen (led-col)
+                circle (as-pair cx cy) 10
+            ]
+        ][
+            append cmds compose [
+                fill-pen 255.255.255
+                text (as-pair (item/offset/x + 8) (item/offset/y + fp-item-height - 16))
+                     (fp-value-text item)
+            ]
         ]
     ]
 
@@ -223,6 +287,38 @@ edit-dialog-panel: none
 edit-dialog-model: none
 edit-dialog-fval:  none
 
+; Aplica valor string a un item del FP y refresca el panel.
+fp-str-apply-and-refresh: func [itm txt pnl mdl] [
+    itm/value: txt
+    pnl/draw: render-fp-panel mdl mdl/size/x mdl/size/y
+]
+
+; Abre diálogo para editar el valor de un str-control en el FP.
+; Usa compose/deep para capturar item, panel-face y model por valor (sin vars de módulo).
+open-str-fp-edit-dialog: func [item panel-face model /local cur-val] [
+    cur-val: any [item/value  ""]
+    view/no-wait compose/deep [
+        title "Editar string"
+        text "Valor:" return
+        field 200 (cur-val)
+        on-enter [
+            fp-str-apply-and-refresh (item) copy face/text (panel-face) (model)
+            unview
+        ]
+        return
+        button "OK" [
+            foreach pf face/parent/pane [
+                if pf/type = 'field [
+                    fp-str-apply-and-refresh (item) copy pf/text (panel-face) (model)
+                    break
+                ]
+            ]
+            unview
+        ]
+        button "Cancelar" [unview]
+    ]
+]
+
 open-edit-dialog: func [item panel-face model /local label-text default-text] [
     edit-dialog-item:  item
     edit-dialog-panel: panel-face
@@ -267,7 +363,11 @@ fp-palette-add-item: func [item-type /local new-id item model w h _cref nid bd-y
         type:    (item-type)
         name:    (rejoin [form item-type "_" new-id])
         label:   [text: (fp-default-label item-type) visible: true]
-        default: (either find [bool-control bool-indicator] item-type [false] [0.0])
+        default: (case [
+            find [bool-control bool-indicator] item-type [false]
+            find [str-control  str-indicator]  item-type [copy ""]
+            true                               [0.0]
+        ])
         offset:  (as-pair fp-palette-x fp-palette-y)
     ]
     append model/front-panel item
@@ -301,6 +401,8 @@ open-fp-palette: func [face x y] [
         button 100 "Indicator"      [fp-palette-add-item 'indicator]      return
         button 100 "Bool Control"   [fp-palette-add-item 'bool-control]   return
         button 100 "Bool Indicator" [fp-palette-add-item 'bool-indicator] return
+        button 100 "Str Control"    [fp-palette-add-item 'str-control]    return
+        button 100 "Str Indicator"  [fp-palette-add-item 'str-indicator]  return
         button      "Cancelar"      [unview]
     ]
 ]
@@ -372,6 +474,9 @@ render-panel: func [model panel-width panel-height /local panel-face] [
                         hit/value: not hit/value
                         face/draw: render-fp-panel face/extra w h
                     ]
+                    all [hit  hit/type = 'str-control] [
+                        open-str-fp-edit-dialog hit face face/extra
+                    ]
                     all [hit  hit/type = 'control] [
                         open-edit-dialog hit face face/extra
                     ]
@@ -388,6 +493,7 @@ render-panel: func [model panel-width panel-height /local panel-face] [
                         hit/value: not hit/value
                         face/draw: render-fp-panel face/extra face/extra/size/x face/extra/size/y
                     ]
+                    all [hit  hit/type = 'str-control]   [open-str-fp-edit-dialog hit face face/extra]
                     all [hit  hit/type = 'control]        [open-edit-dialog hit face face/extra]
                     none? hit                              [open-fp-palette face mouse-x mouse-y]
                     ; indicador: no hacer nada
@@ -434,11 +540,15 @@ load-panel-from-diagram: func [diagram-block /local fp-block fp-item-spec result
         offset-y: 20
         parse fp-block [
             any [
-                set kw ['control | 'indicator | 'bool-control | 'bool-indicator]
+                set kw ['control | 'indicator | 'bool-control | 'bool-indicator | 'str-control | 'str-indicator]
                 set fp-item-spec block! (
                     item: make-fp-item fp-item-spec
                     item/type:      kw
-                    item/data-type: either find [bool-control bool-indicator] kw ['boolean] ['numeric]
+                    item/data-type: case [
+                        find [bool-control bool-indicator] kw ['boolean]
+                        find [str-control  str-indicator]  kw ['string]
+                        true                               ['numeric]
+                    ]
                     if all [zero? item/offset/x  zero? item/offset/y] [
                         item/offset: as-pair 20 offset-y
                         offset-y: offset-y + fp-item-height + 10
@@ -463,6 +573,8 @@ save-panel-to-diagram: func [front-panel-items /local items item kw spec] [
             item/type = 'control        ['control]
             item/type = 'bool-control   ['bool-control]
             item/type = 'bool-indicator ['bool-indicator]
+            item/type = 'str-control    ['str-control]
+            item/type = 'str-indicator  ['str-indicator]
             true                        ['indicator]
         ]
         spec: compose/deep [

--- a/tests/test-blocks.red
+++ b/tests/test-blocks.red
@@ -4,7 +4,7 @@ do %../src/graph/blocks.red
 
 suite "blocks — registro"
 
-assert "registra 17 bloques (8 originales + 9 booleanos)" (17 = length? block-registry)
+assert "registra 23 bloques (8 originales + 9 booleanos + 6 string)" (23 = length? block-registry)
 assert "const está en el registro"     (not none? find-block 'const)
 assert "add está en el registro"       (not none? find-block 'add)
 assert "find-block devuelve none para bloques inexistentes" (none? find-block 'nonexistent)
@@ -73,3 +73,41 @@ suite "blocks — booleanos: emit"
 
 assert "and-op emit es [result: a and b]"  ([result: a and b] = b-and/emit)
 assert "not-op emit es [result: not a]"    ([result: not a]   = b-not/emit)
+
+suite "blocks — string: registro"
+
+assert "str-const está en el registro"     (not none? find-block 'str-const)
+assert "str-control está en el registro"   (not none? find-block 'str-control)
+assert "str-indicator está en el registro" (not none? find-block 'str-indicator)
+assert "concat está en el registro"        (not none? find-block 'concat)
+assert "str-length está en el registro"    (not none? find-block 'str-length)
+assert "to-string está en el registro"     (not none? find-block 'to-string)
+
+suite "blocks — string: tipos de puertos"
+
+b-sc:  find-block 'str-const
+b-cat: find-block 'concat
+b-len: find-block 'str-length
+b-ts:  find-block 'to-string
+
+sc-out1:  first b-sc/outputs
+cat-in1:  first b-cat/inputs
+cat-out1: first b-cat/outputs
+len-in1:  first b-len/inputs
+len-out1: first b-len/outputs
+ts-in1:   first b-ts/inputs
+ts-out1:  first b-ts/outputs
+
+assert "str-const: output es tipo string"   ('string = sc-out1/type)
+assert "concat: input a es tipo string"     ('string = cat-in1/type)
+assert "concat: output es tipo string"      ('string = cat-out1/type)
+assert "str-length: input es tipo string"   ('string = len-in1/type)
+assert "str-length: output es tipo number"  ('number = len-out1/type)
+assert "to-string: input es tipo number"    ('number = ts-in1/type)
+assert "to-string: output es tipo string"   ('string = ts-out1/type)
+
+suite "blocks — string: emit"
+
+assert "concat emit es [result: rejoin [a b]]"             ([result: rejoin [a b]]        = b-cat/emit)
+assert "str-length emit es [result: to-float length? a]"   ([result: to-float length? a]  = b-len/emit)
+assert "to-string emit es [result: form a]"                ([result: form a]              = b-ts/emit)

--- a/tests/test-compiler.red
+++ b/tests/test-compiler.red
@@ -100,6 +100,53 @@ assert "bool-const es boolean input"               (node-boolean-input? tbn1)
 assert "bool-const (bool_B) es boolean"            (node-boolean-input? tbn2)
 assert "control numérico NO es boolean input"      (not node-boolean-input? tc-num)
 
+; ── Tests compile-body con bloques string ────────────────────────────
+suite "compile-body — string"
+
+; str_A("hola") ──┐
+; str_B(" mundo") ─┘── concat ── result
+ts-diag: make-diagram "test-str-vi"
+tsn1: make-node [id: 30  type: 'str-const  name: "str_A"  x: 0   y: 0]
+tsn1/config: [default "hola"]
+tsn2: make-node [id: 31  type: 'str-const  name: "str_B"  x: 0   y: 60]
+tsn2/config: [default " mundo"]
+tsn3: make-node [id: 32  type: 'concat     name: "cat_1"  x: 200 y: 30]
+tsn4: make-node [id: 33  type: 'str-indicator  name: "ind_s"  x: 300 y: 30]
+append ts-diag/nodes tsn1
+append ts-diag/nodes tsn2
+append ts-diag/nodes tsn3
+append ts-diag/nodes tsn4
+append ts-diag/wires make-wire [from: 30  from-port: 'result  to: 32  to-port: 'a]
+append ts-diag/wires make-wire [from: 31  from-port: 'result  to: 32  to-port: 'b]
+
+str-body: compile-body ts-diag
+assert "compile-body string no está vacío"         (not empty? str-body)
+assert "contiene variable str_A_result"            (not none? find str-body 'str_A_result)
+assert "contiene variable str_B_result"            (not none? find str-body 'str_B_result)
+assert "contiene variable cat_1_result"            (not none? find str-body 'cat_1_result)
+
+do str-body
+assert "str_A_result es 'hola' tras execute"       ("hola"       = str_A_result)
+assert "str_B_result es ' mundo' tras execute"     (" mundo"     = str_B_result)
+assert "cat_1_result es 'hola mundo' tras execute" ("hola mundo" = cat_1_result)
+
+; node-string-input?: chequea si el primer output del bloque es string
+tc-str: make-node [id: 34  type: 'str-control  name: "ctrl_s"  x: 0  y: 0]
+assert "str-const es string input"                 (node-string-input? tsn1)
+assert "str-control es string input"               (node-string-input? tc-str)
+assert "control numérico NO es string input"       (not node-string-input? tc-num)
+assert "bool-const NO es string input"             (not node-string-input? tbn1)
+
+; str-length: número de caracteres
+tsn-len: make-node [id: 35  type: 'str-length  name: "len_1"  x: 0  y: 0]
+tsl-diag: make-diagram "test-len-vi"
+append tsl-diag/nodes tsn1
+append tsl-diag/nodes tsn-len
+append tsl-diag/wires make-wire [from: 30  from-port: 'result  to: 35  to-port: 'a]
+len-body: compile-body tsl-diag
+do len-body
+assert "str-length de 'hola' es 4.0"               (4.0 = len_1_result)
+
 ; ── Tests save-vi / load-vi ──────────────────────────────────────────
 suite "save-vi / load-vi"
 
@@ -209,3 +256,17 @@ assert "item 3: type indicator"               ('indicator = fp-li1/type)
 assert "item 3: name correcto"                ("ind_1" = fp-li1/name)
 assert "item 3: label/text correcto"          ("R" = fp-li1/label/text)
 assert "item 3: offset/y correcto"            (170 = fp-li1/offset/y)
+
+; ── Independencia de valores entre str-control y str-indicator ────────
+suite "FP items — string independence"
+
+sc-a: make-fp-item [id: 10  type: 'str-control   name: "sc_a"  label: [text: "A" visible: true]  offset: 20x40]
+sc-b: make-fp-item [id: 11  type: 'str-indicator  name: "si_b"  label: [text: "B" visible: true]  offset: 20x80]
+
+assert "str-control valor inicial vacío"        ("" = sc-a/value)
+assert "str-indicator valor inicial vacío"      ("" = sc-b/value)
+assert "valores iniciales son objetos distintos" (not same? sc-a/value sc-b/value)
+
+sc-a/value: "hello"
+assert "cambiar control no afecta indicador"    ("" = sc-b/value)
+assert "control tiene nuevo valor"              ("hello" = sc-a/value)


### PR DESCRIPTION
## Summary

- **Wire string**: color rosa (`220.100.160`) con patrón daseado (Draw dialect, sin dash nativo)
- **Bloques nuevos**: `str-const`, `str-control`, `str-indicator`, `concat`, `str-length`, `to-string` con tipos de puerto `'string`
- **Front Panel**: `str-control` como field editable, `str-indicator` como text; aspecto LabVIEW (label oscura + campo blanco)
- **Compilador**: soporte completo en `compile-body` y `compile-diagram` (run-body + ui-layout) para entradas/salidas string
- **Error visual**: al intentar conectar tipos incompatibles se muestra wire rojo daseado con marca X; desaparece al iniciar nueva conexión o hacer clic

## Test plan

- [x] Añadir str-const desde paleta BD → doble clic → editar valor → se muestra en el bloque
- [x] Abrir dos str-consts y editar ambas → valores independientes (bug de literal compartida corregido)
- [x] Conectar str-const → concat → str-indicator; ejecutar Run → resultado visible en FP
- [x] Intentar conectar un puerto `number` con un puerto `string` → aparece wire rojo con X
- [x] `./red-cli tests/run-all.red` → 132 tests PASS

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)