### PR TITLE
fix(panel): pen colorea texto en Draw — corrige colores y offset GTK

### DIFF
--- a/.claude/skills/red-lang/SKILL.md
+++ b/.claude/skills/red-lang/SKILL.md
@@ -684,14 +684,34 @@ spline/closed 10x10 50x80 100x20 150x90    ; closed spline
 ; text — position then string
 text 10x10 "Hello"
 
-; font — set font before text
-font make font! [name: "Arial" size: 14 bold: true color: 0.0.0]
+; font — controla tipografía (familia, tamaño, negrita)
+font make font! [name: "Arial" size: 14 bold: true]
 text 10x10 "Bold Arial 14"
 
-; Text color is controlled by fill-pen
-fill-pen 0.0.0      ; black text
-text 10x10 "Black text"
+; Color del texto: se controla con pen, NO con fill-pen ni font/color
+pen 255.0.0         ; texto rojo
+text 10x10 "Texto rojo"
+pen 0.0.0           ; texto negro
+text 10x10 "Texto negro"
 ```
+
+> ⚠️ **GOTCHA — Color de texto en Draw (verificado en GTK/Linux):**
+>
+> - **`pen`** es lo que colorea el texto. Cambia antes de cada `text`.
+> - **`fill-pen`** NO afecta el color del texto (solo relleno de formas).
+> - **`font!/color`** es ignorado por GTK/Linux — no tiene efecto sobre el color del texto.
+> - **`pen off`** antes de `text` produce texto **gris** (color del sistema), no invisible.
+> - **`pen` sangra entre comandos `text`**: si no reseteas, el siguiente `text` hereda el color anterior.
+> - **`line-width`** no afecta al texto.
+>
+> Patrón correcto para resetear estado Draw entre items (panel.red):
+> ```red
+> pen 0.0.0  fill-pen off  line-width 1
+> ; — pen 0.0.0   → texto negro (reset crítico)
+> ; — fill-pen off → formas sin relleno (reset de formas)
+> ; — line-width 1 → grosor por defecto
+> ; — font!/color  → NO usar para color, no funciona en GTK
+> ```
 
 ### Styling
 ```red

--- a/docs/GTK_ISSUES.md
+++ b/docs/GTK_ISSUES.md
@@ -78,6 +78,22 @@ Cuando Red migre a 64-bit, este problema desaparece. QTorres debe seguir ese roa
 
 ---
 
+### GTK-010: `text` en Draw usa baseline como Y en vez de top-left
+
+**Severidad:** Media
+**Impacto en QTorres:** El texto en el Front Panel aparece desplazado ~5px hacia arriba en Linux respecto a Windows. Afecta a todos los comandos `text` en Draw dialect.
+
+**Descripción:**
+En Linux/GTK (Cairo), el comando `text x y "..."` del Draw dialect posiciona el texto con el punto Y en la **baseline** (línea base de la tipografía). En Windows/GDI, Y es la esquina superior izquierda del glyph box. La diferencia es aproximadamente la mitad del tamaño de fuente (~5px con size 11).
+
+**Workaround temporal:** Constante `fp-text-dy` en `panel.red`:
+```red
+fp-text-dy: either system/platform = 'Linux [8] [0]
+```
+Se suma a la coordenada Y de cada comando `text` en `render-fp-item`.
+
+---
+
 ## Estado de las contribuciones
 
 | Bug | Issue en red/red | Estado |
@@ -91,6 +107,7 @@ Cuando Red migre a 64-bit, este problema desaparece. QTorres debe seguir ese roa
 | GTK-007 Modal pierde foco teclado | — | Pendiente de crear |
 | GTK-008 `request-file/save` abre diálogo de carpetas | — | Workaround: diálogo VID propio |
 | GTK-009 `request-file` no permite controlar tamaño | — | Posible: file browser VID propio |
+| GTK-010 `text` Y es baseline en GTK vs top en Windows | [#5678](https://github.com/red/red/issues/5678) CLOSED | Workaround: `fp-text-dy` en panel.red — eliminar cuando se actualice red-view |
 
 ---
 

--- a/src/ui/panel/panel.red
+++ b/src/ui/panel/panel.red
@@ -19,6 +19,10 @@ fp-label-height:     20
 fp-label-above:      18
 fp-run-button-height: 30
 
+; GTK-010: en Linux/GTK, Draw text usa baseline como Y en vez de top-left.
+; Compensamos añadiendo fp-text-dy a todas las coordenadas Y de texto.
+fp-text-dy: either system/platform = 'Linux [8] [0]
+
 fp-color?: func [item-type] [
     either find [control bool-control str-control] item-type [fp-control-color] [fp-indicator-color]
 ]
@@ -160,8 +164,6 @@ render-fp-grid: func [w h /local cmds gx gy] [
     cmds
 ]
 
-fp-black-font: make font! [color: 0.0.0]
-
 ; Genera segmentos de línea discontinua a lo largo de un rectángulo
 dashed-box: func [x1 y1 x2 y2 dash gap /local cmds pos lim step] [
     cmds: copy []
@@ -194,8 +196,8 @@ dashed-box: func [x1 y1 x2 y2 dash gap /local cmds pos lim step] [
 
 render-fp-item: func [item selected? /local cmds col border-col type-lbl led-col cx cy field-y field-h lx ly lw bh] [
     cmds: copy []
-    ; Reset estado Draw — evita leak de font/pen/fill-pen del item anterior
-    append cmds compose [pen 0.0.0  fill-pen off  line-width 1  font (fp-black-font)]
+    ; Reset estado Draw — pen 0.0.0 es crítico: evita bleed de color de texto
+    append cmds [pen 0.0.0  fill-pen off  line-width 1]
 
     ; ── Label encima del body (todos los tipos) ───────────────────────────────────────────
     if all [item/label  object? item/label  item/label/visible] [
@@ -206,7 +208,7 @@ render-fp-item: func [item selected? /local cmds col border-col type-lbl led-col
             ly: ly + item/label/offset/y
         ]
         append cmds compose [
-            text (as-pair lx ly) (any [item/label/text ""])
+            text (as-pair lx (ly + fp-text-dy)) (any [item/label/text ""])
         ]
     ]
 
@@ -227,8 +229,8 @@ render-fp-item: func [item selected? /local cmds col border-col type-lbl led-col
             ]
         ]
         append cmds compose [
-            pen off  fill-pen 20.20.20
-            text (as-pair (item/offset/x + 4) (item/offset/y + 4)) (fp-value-text item)
+            pen 20.20.20  fill-pen off
+            text (as-pair (item/offset/x + 4) (item/offset/y + 4 + fp-text-dy)) (fp-value-text item)
         ]
     ][
         ; Numeric / Boolean: caja de color
@@ -241,8 +243,8 @@ render-fp-item: func [item selected? /local cmds col border-col type-lbl led-col
         ]
         type-lbl: fp-type-label? item/type
         append cmds compose [
-            fill-pen 220.230.240  pen off
-            text (as-pair (item/offset/x + 4) (item/offset/y + 5)) (type-lbl)
+            pen 220.230.240  fill-pen off
+            text (as-pair (item/offset/x + 4) (item/offset/y + 5 + fp-text-dy)) (type-lbl)
         ]
         either item/data-type = 'boolean [
             led-col: either item/value [0.180.0] [180.0.0]
@@ -254,8 +256,8 @@ render-fp-item: func [item selected? /local cmds col border-col type-lbl led-col
             ]
         ][
             append cmds compose [
-                fill-pen 255.255.255  pen off
-                text (as-pair (item/offset/x + 4) (item/offset/y + fp-item-height - 14))
+                pen 255.255.255  fill-pen off
+                text (as-pair (item/offset/x + 4) (item/offset/y + fp-item-height - 14 + fp-text-dy))
                      (fp-value-text item)
             ]
         ]
@@ -793,7 +795,7 @@ if find form system/options/script "panel.red" [
         pane:   reduce [
             make face! [
                 type: 'base  offset: 10x8  size: 400x25  color: 200.203.212
-                draw: [pen 60.70.90  text 5x15 "Drag items | dbl-click = edit value | Delete = remove"]
+                draw: compose [pen 60.70.90  text (as-pair 5 (15 + fp-text-dy)) "Drag items | dbl-click = edit value | Delete = remove"]
             ]
             panel
         ]

--- a/tests/test-font-bleed.red
+++ b/tests/test-font-bleed.red
@@ -1,0 +1,142 @@
+Red [
+    Title:   "QTorres — Test font/fill-pen color bleed en Draw dialect"
+    Purpose: {
+        Verifica cómo se colorea texto en Draw y si hay bleed entre items.
+
+        SECCIÓN A: font! color  → ¿funciona para colorear texto?
+        SECCIÓN B: fill-pen     → ¿funciona para colorear texto? (método de canvas.red)
+        SECCIÓN C: pen          → ¿funciona para colorear texto?
+        SECCIÓN D: bleed real   → simula render-fp-item: item rojo seguido de items
+                                   sin reset, con reset fill-pen off, con reset fill-pen negro
+    }
+    Needs: 'View
+]
+
+colors: [
+    [220.0.0    "Rojo"  ]
+    [0.180.0    "Verde" ]
+    [0.0.220    "Azul"  ]
+    [230.120.0  "Naranja"]
+    [150.0.200  "Morado"]
+    [0.180.180  "Cyan"  ]
+]
+
+header-font: make font! [size: 10]
+
+draw-header: func [x y txt] [
+    compose [pen off fill-pen 30.30.30  font (header-font)  text (as-pair x y) (txt)]
+]
+
+draw-box: func [x y] [
+    compose [
+        pen 80.80.80  line-width 1  fill-pen 235.235.235
+        box (as-pair x y) (as-pair (x + 115) (y + 22))
+        pen off  fill-pen off
+    ]
+]
+
+d: copy []
+
+; ════ SECCIÓN A: font! color ══════════════════════════════════════════
+append d draw-header 10 8 "A) font! color"
+
+y: 25
+foreach item colors [
+    col: item/1  lbl: item/2
+    append d draw-box 10 y
+    append d compose [
+        font (make font! [color: (col) size: 11])
+        text (as-pair 15 (y + 5)) (lbl)
+    ]
+    y: y + 28
+]
+
+; ════ SECCIÓN B: fill-pen (método canvas.red) ════════════════════════
+append d draw-header 140 8 "B) fill-pen (canvas.red)"
+
+y: 25
+foreach item colors [
+    col: item/1  lbl: item/2
+    append d draw-box 140 y
+    append d compose [
+        fill-pen (col)
+        text (as-pair 145 (y + 5)) (lbl)
+    ]
+    y: y + 28
+]
+
+; ════ SECCIÓN C: pen ══════════════════════════════════════════════════
+append d draw-header 270 8 "C) pen"
+
+y: 25
+foreach item colors [
+    col: item/1  lbl: item/2
+    append d draw-box 270 y
+    append d compose [
+        pen (col)
+        text (as-pair 275 (y + 5)) (lbl)
+    ]
+    y: y + 28
+]
+
+; ════ SECCIÓN D: bleed real ═══════════════════════════════════════════
+; Simula render-fp-item: item 1 pone fill-pen naranja (como un indicador)
+; luego items siguientes con distintos niveles de reset
+
+append d draw-header 400 8 "D) Bleed real — tras fill-pen naranja"
+
+; sub-cabeceras
+append d compose [
+    fill-pen 30.30.30
+    text 400x20 "d1:sin reset"
+    text 470x20 "d2:fill-pen off"
+    text 545x20 "d3:fill-pen negro"
+]
+
+; Item 0 — pone fill-pen naranja (item anterior "contaminante")
+append d compose [
+    pen 80.80.80  line-width 1  fill-pen 230.120.0
+    box 400x36 610x58
+    fill-pen 230.120.0
+    text 410x42 "Item anterior — fill-pen naranja (230.120.0)"
+]
+
+; Fila 1: texto negro esperado
+append d draw-box 400 65
+append d draw-box 470 65
+append d draw-box 545 65
+
+; d1: sin reset — ¿hereda naranja?
+append d compose [text 405x71 "Negro?"]
+
+; d2: reset fill-pen off — ¿qué color queda?
+append d compose [fill-pen off  text 475x71 "Negro?"]
+
+; d3: reset fill-pen negro explícito
+append d compose [fill-pen 0.0.0  text 550x71 "Negro?"]
+
+; Fila 2: segunda fila para ver si persiste
+append d draw-box 400 95
+append d draw-box 470 95
+append d draw-box 545 95
+
+append d compose [text 405x101 "Negro?"]
+append d compose [fill-pen off  text 475x101 "Negro?"]
+append d compose [fill-pen 0.0.0  text 550x101 "Negro?"]
+
+; ── Consola ───────────────────────────────────────────────────────────
+print "^/=== test-font-bleed (completo) ==="
+print "A) font! color    -> ¿cada texto en su color?"
+print "B) fill-pen       -> ¿cada texto en su color? (método canvas.red)"
+print "C) pen            -> ¿cada texto en su color?"
+print "D) bleed real     -> tras fill-pen naranja, d1/d2/d3 ¿qué color tienen?"
+print ""
+
+; ── Ventana ───────────────────────────────────────────────────────────
+view/no-wait layout [
+    title "test-font-bleed completo — QTorres"
+    backdrop 210.213.220
+    base 640x200 draw d
+    button "Cerrar" [quit]
+]
+do-events

--- a/tests/test-pen-text.red
+++ b/tests/test-pen-text.red
@@ -1,0 +1,169 @@
+Red [
+    Title:   "QTorres — Test exhaustivo: pen colorea texto en Draw"
+    Purpose: {
+        Sabemos que pen controla el color del texto en Draw dialect.
+        Este test intenta romperlo con todos los casos extremos relevantes
+        para panel.red y canvas.red.
+    }
+    Needs: 'View
+]
+
+; ── helpers ──────────────────────────────────────────────────────────
+
+hf: make font! [size: 9]   ; font para cabeceras (sin color — heredará pen)
+
+; Caja de fondo neutro
+bg: func [x y w h] [
+    compose [
+        pen 100.100.100  line-width 1  fill-pen 240.240.240
+        box (as-pair x y) (as-pair (x + w) (y + h))
+        fill-pen off
+    ]
+]
+
+; Título de sección
+title: func [x y txt] [
+    compose [pen 20.20.20  fill-pen off  font (hf)  text (as-pair x y) (txt)]
+]
+
+; Separador visual
+sep: func [x y w] [
+    compose [pen 160.160.160  line-width 1  line (as-pair x y) (as-pair (x + w) y)]
+]
+
+d: copy []
+
+; ════════════════════════════════════════════════════════════════════
+; BLOQUE 1 — pen básico: ¿cada color aparece distinto?
+; ════════════════════════════════════════════════════════════════════
+append d title 10 8 "1) pen basico — 6 colores distintos"
+
+colors: [220.0.0 "Rojo" 0.180.0 "Verde" 0.0.220 "Azul" 230.120.0 "Naranja" 150.0.200 "Morado" 0.180.180 "Cyan"]
+x: 10
+foreach [col lbl] colors [
+    append d bg x 22 70 22
+    append d compose [pen (col)  fill-pen off  text (as-pair (x + 4) 29) (lbl)]
+    x: x + 76
+]
+
+; ════════════════════════════════════════════════════════════════════
+; BLOQUE 2 — bleed: ¿pen persiste al siguiente text sin reset?
+; ════════════════════════════════════════════════════════════════════
+append d sep 10 52 580
+append d title 10 56 "2) Bleed: tras pen naranja, texto siguiente sin reset — ¿naranja o negro?"
+
+append d bg 10 70 120 22
+append d bg 140 70 120 22
+append d bg 270 70 120 22
+append d compose [
+    pen 230.120.0
+    text 14x77 "Item 1 — NARANJA"
+    text 144x77 "Item 2 — sin reset"
+    pen 0.0.0
+    text 274x77 "Item 3 — pen 0.0.0"
+]
+
+; ════════════════════════════════════════════════════════════════════
+; BLOQUE 3 — pen off: ¿qué color tiene el texto con pen off?
+; ════════════════════════════════════════════════════════════════════
+append d sep 10 100 580
+append d title 10 104 "3) pen off antes de text — ¿invisible, negro, gris?"
+
+append d bg 10 118 180 22
+append d compose [pen 220.0.0  text 14x125 "Antes: pen rojo"]
+append d bg 200 118 180 22
+append d compose [pen off  text 204x125 "Despues: pen off — ¿que color?"]
+
+; ════════════════════════════════════════════════════════════════════
+; BLOQUE 4 — fill-pen vs pen: ¿fill-pen puede sobreescribir pen para texto?
+; ════════════════════════════════════════════════════════════════════
+append d sep 10 148 580
+append d title 10 152 "4) fill-pen vs pen — ¿cual manda en texto?"
+
+append d bg 10 166 170 22
+append d compose [pen 220.0.0  fill-pen 0.0.220  text 14x173 "pen=rojo fill-pen=azul"]
+append d bg 190 166 170 22
+append d compose [pen 0.0.220  fill-pen 220.0.0  text 194x173 "pen=azul fill-pen=rojo"]
+append d bg 370 166 170 22
+append d compose [pen off  fill-pen 0.180.0  text 374x173 "pen=off  fill-pen=verde"]
+
+; ════════════════════════════════════════════════════════════════════
+; BLOQUE 5 — ¿dibujar formas cambia pen para el texto siguiente?
+; ════════════════════════════════════════════════════════════════════
+append d sep 10 196 580
+append d title 10 200 "5) Dibujar forma con pen azul — ¿texto siguiente hereda azul?"
+
+append d compose [
+    pen 0.0.220  line-width 2  fill-pen off
+    box 10x214 80x236
+]
+append d bg 90 214 180 22
+append d compose [text 94x221 "Texto sin reset de pen — ¿azul?"]
+append d bg 280 214 180 22
+append d compose [pen 0.0.0  text 284x221 "Texto con pen 0.0.0 — negro"]
+
+; ════════════════════════════════════════════════════════════════════
+; BLOQUE 6 — line-width afecta al texto? (grosor de trazo)
+; ════════════════════════════════════════════════════════════════════
+append d sep 10 244 580
+append d title 10 248 "6) line-width alto — ¿afecta al texto?"
+
+append d bg 10 262 150 22
+append d compose [pen 0.0.0  line-width 1  text 14x269 "line-width 1"]
+append d bg 170 262 150 22
+append d compose [pen 0.0.0  line-width 5  text 174x269 "line-width 5"]
+append d bg 330 262 150 22
+append d compose [pen 0.0.0  line-width 10  text 334x269 "line-width 10"]
+
+; ════════════════════════════════════════════════════════════════════
+; BLOQUE 7 — reset completo tipo panel.red: ¿es suficiente?
+; ════════════════════════════════════════════════════════════════════
+append d sep 10 292 580
+append d title 10 296 "7) Reset tipo panel.red tras contaminacion maxima"
+
+; Contaminamos todo: pen morado, fill-pen naranja, line-width 8
+append d compose [
+    pen 150.0.200  fill-pen 230.120.0  line-width 8
+    box 10x310 200x332
+]
+append d bg 10 340 560 22
+; Reset igual que panel.red
+rf: make font! [color: 0.0.0]
+append d compose [
+    pen 0.0.0  fill-pen off  line-width 1  font (rf)
+    text 14x347 "Tras reset panel.red (pen 0.0.0 fill-pen off line-width 1 font negro) — ¿negro limpio?"
+]
+
+; ════════════════════════════════════════════════════════════════════
+; BLOQUE 8 — texto blanco sobre fondo oscuro con pen
+; ════════════════════════════════════════════════════════════════════
+append d sep 10 370 580
+append d title 10 374 "8) pen blanco sobre fondo oscuro — ¿visible?"
+
+append d compose [
+    pen 30.30.30  line-width 1  fill-pen 30.40.60
+    box 10x388 280x410
+    fill-pen off
+    pen 255.255.255
+    text 14x395 "pen blanco (255.255.255) sobre fondo oscuro"
+]
+append d compose [
+    pen 30.30.30  line-width 1  fill-pen 30.40.60
+    box 290x388 580x410
+    fill-pen off
+    pen 255.255.0
+    text 294x395 "pen amarillo (255.255.0) sobre fondo oscuro"
+]
+
+; ── consola ──────────────────────────────────────────────────────────
+print "^/=== test-pen-text ==="
+print "8 bloques — describe cada resultado para diagnostico completo"
+print ""
+
+view/no-wait layout [
+    title "test-pen-text — QTorres"
+    backdrop 200.203.210
+    base 600x425 draw d
+    button "Cerrar" [quit]
+]
+do-events


### PR DESCRIPTION
## Summary

- Corrige el método para colorear texto en Draw dialect: `pen` en vez de `fill-pen`/`pen off` (verificado con tests)
- Elimina `fp-black-font` (código muerto — `font!/color` es ignorado por GTK/Linux)
- Añade `fp-text-dy` para compensar GTK-010: en GTK el comando `text` usa baseline como Y en vez de top-left (offset 8px en Linux, 0 en Windows)
- Documenta GTK-010 en `GTK_ISSUES.md`, relacionado con [red/red#5678](https://github.com/red/red/issues/5678) ya cerrado upstream — eliminar `fp-text-dy` cuando se actualice `red-view`
- Actualiza skill `red-lang` con gotchas verificados sobre color de texto en Draw
- Añade `tests/test-font-bleed.red` y `tests/test-pen-text.red` para diagnóstico

## Test plan
- [ ] `./red-view src/ui/panel/panel.red` — verificar que los textos de items (DBL/TF/STR, valores, labels) se ven correctamente posicionados y con color
- [ ] Comprobar que no hay color bleed entre items al seleccionar/deseleccionar

🤖 Generated with [Claude Code](https://claude.com/claude-code)