### PR TITLE
feat(#15): For Loop — estructura de control con terminal N e índice i

### DIFF
--- a/examples/for-loop-basico.qvi
+++ b/examples/for-loop-basico.qvi
@@ -1,0 +1,80 @@
+Red [Title: "for-loop-basico" Needs: 'View]
+
+; Ejemplo: suma acumulativa 0+1+2+...+(N-1) usando For Loop con Shift Register
+;
+; Estructura del diagrama:
+;   ctrl_n  (control numérico, N=10)  → terminal [N] del For Loop
+;   for-loop_1 (For Loop, 10 iteraciones, i: 0..9)
+;     SR: sr_acc  (acumulador, init 0.0)
+;     Interno:
+;       iadd  (add)  — sr_acc + i  → nuevo acc
+;     SR sr_acc → ind_1 (indicator)
+;
+; Resultado esperado: 0+1+2+...+9 = 45.0
+
+qvi-diagram: [
+    meta: [description: "Suma 0+1+...+(N-1) con For Loop y Shift Register" version: 1 author: "" tags: [for-loop sr]]
+    icon: []
+    block-diagram: [
+        nodes: [
+            node [id: 1  type: 'control    name: "ctrl_n"
+                  label: [text: "N" visible: true]  x: 40  y: 80  config: [default 10.0]]
+            node [id: 2  type: 'indicator  name: "ind_1"
+                  label: [text: "Resultado" visible: true]  x: 520  y: 150]
+        ]
+        wires: [
+            wire [from: 1  from-port: result  to: 3  to-port: count]
+            wire [from: 3  from-port: sr_acc  to: 2  to-port: value]
+        ]
+        structures: [
+            for-loop [
+                id: 3  name: "for-loop_1"  label: [text: "For Loop" visible: true]
+                x: 120  y: 60  w: 340  h: 180
+                shift-registers: [
+                    sr [id: 10  name: "sr_acc"  data-type: 'number  init-value: 0.0  y-offset: 60]
+                ]
+                nodes: [
+                    node [id: 4  type: 'add  name: "iadd"
+                          label: [text: "Add" visible: false]  x: 70  y: 60]
+                ]
+                wires: [
+                    wire [from: -1  from-port: sr_acc        to: 4  to-port: a]
+                    wire [from: -3  from-port: _for-loop_1_i  to: 4  to-port: b]
+                    wire [from: 4   from-port: result         to: -2  to-port: sr_acc]
+                ]
+            ]
+        ]
+    ]
+]
+
+; --- CÓDIGO GENERADO — no editar, se regenera al guardar ---
+either empty? system/options/args [
+    view layout [
+        text "N:" f_ctrl_n: field "10.0" return
+        text "Resultado:" t_ind_1: text "---" return
+        button "Run" [
+            ctrl_n_result: to-float f_ctrl_n/text
+            _for-loop_1_N: to-integer ctrl_n_result
+            _sr_acc: 0.0
+            _for-loop_1_i: 0
+            loop _for-loop_1_N [
+                iadd_result: _sr_acc + _for-loop_1_i
+                _sr_acc: iadd_result
+                _for-loop_1_i: _for-loop_1_i + 1
+                do-events/no-wait
+            ]
+            t_ind_1/text: form _sr_acc
+        ]
+    ]
+][
+    ctrl_n_result: 10.0
+    _for-loop_1_N: to-integer ctrl_n_result
+    _sr_acc: 0.0
+    _for-loop_1_i: 0
+    loop _for-loop_1_N [
+        iadd_result: _sr_acc + _for-loop_1_i
+        _sr_acc: iadd_result
+        _for-loop_1_i: _for-loop_1_i + 1
+    ]
+    print rejoin ["Resultado: " _sr_acc]
+]

--- a/progress.md
+++ b/progress.md
@@ -1,4 +1,33 @@
-# Progress — Issue #14: While Loop
+# Progress — Issue #15: For Loop
+
+## Session Log
+
+### 2026-03-25 — Implementación completa
+
+**Tests:** 271/271 PASS (partíamos de 241/241 al cerrar #14)
+
+**Fases completadas:**
+- Phase 0: Modelo (model.red label por tipo, blocks.red registra 'for-loop)
+- Phase 1: Render (terminal [N] cuadrado naranja top-left, [●] solo while-loop)
+- Phase 2: Interacción (wiring [N], paleta "For", delete limpia wire N)
+- Phase 3: Compilador (compile-structure bifurcado, `loop N [...]`, to-integer, /no-gui)
+- Phase 4: Serialización (for-loop en serialize/load/format-qvi)
+- Phase 5: Tests + ejemplo for-loop-basico.qvi (0+1+...+9=45)
+
+**Bug corregido durante #15:**
+- `make-wire` convierte `to-port` a `word!` — todas las comparaciones `"count"` cambiadas a `'count`
+- `compile-structure` emitía `do-events/no-wait` también en rama headless → cuelga
+  Solución: refinamiento `/no-gui` en `compile-structure`; `compile-body` usa `/no-gui`
+- `compile-body` y `compile-diagram` solo manejaban `'while-loop` → `'for-loop` se saltaba
+  Solución: `find [while-loop for-loop] item/type` en ambos
+
+**Ejecución del ejemplo headless:**
+`./red-cli examples/for-loop-basico.qvi headless` → `Resultado: 45.0`
+(sin args → rama GUI, requiere red-view; con cualquier arg → rama headless)
+
+---
+
+# Progress histórico — Issue #14: While Loop
 
 ## Session Log
 
@@ -81,3 +110,79 @@
 - [i] offset visual ligeramente desplazado
 - Hit-test resize requiere clic un poco fuera del borde
 - Terminal [i] no movible (futuro)
+
+### 2026-03-24 — Entrega 14a COMPLETA — inicio 14b (shift registers)
+**Estado confirmado:** 187/187 PASS. Todas las fases 0-6 verificadas en código.
+- compile-structure en compiler.red (funciones: compile-structure, compile-body, compile-diagram)
+- round-trip while-loop en test-compiler.red (suites de test-file-io)
+- examples/while-loop-basico.qvi presente
+- task_plan.md actualizado (phases 4-6 checked)
+
+### 2026-03-24 — Phase 7 completada (shift register model)
+**Implementado:**
+- `make-shift-register` en model.red — constructor con id, name, data-type, init-value, y-offset
+- `shift-regs: copy []` añadido a `make-structure` (campo nuevo)
+- init-value por defecto: `""` si data-type = 'string, `0.0` en todos los demás casos
+- 21 tests nuevos en test-model.red (208/208 PASS)
+
+**14b COMPLETA — Shift Registers**
+- ~~Phase 7: make-shift-register en model.red~~ ✅
+- ~~Phase 8: render terminales ▲/▼ en canvas.red~~ ✅
+- ~~Phase 9: hit-test + wiring de SRs~~ ✅
+- ~~Phase 10: compilador con inicialización/actualización SRs~~ ✅
+- ~~Phase 11: serialización SRs en file-io.red~~ ✅
+- ~~Phase 12: tests + ejemplo while-loop-suma.qvi~~ ✅
+
+### 2026-03-24 — Phase 8 completada (render SR)
+**Implementado en canvas.red:**
+- Constante `sr-terminal-half: 6`
+- Helper `sr-type-color` — mismo patrón que `wire-data-color` (number=naranja, bool=verde, string=rosa)
+- `render-structure` step 5: loop sobre `st/shift-regs`:
+  - ▲ (triángulo apuntando arriba) en borde izquierdo (lectura)
+  - ▼ (triángulo apuntando abajo) en borde derecho (escritura)
+  - texto `init-value` junto al ▲ (visible cuando sin wire externo)
+- Steps 5-10 existentes renumerados a 6-11
+**Tests:** 208/208 PASS (solo render, sin tests de render puro)
+
+### 2026-03-24 — Phase 9 completada (interacción SR en canvas)
+**Implementado en canvas.red:**
+- `make-diagram-model` extendido: `wire-src-sr`, `selected-sr`
+- `hit-structure-sr`: detecta clic en ▲/▼, devuelve `[struct sr 'left|'right]`
+- `render-structure` y `render-bd`: wires SR (int SR-left, int SR-right, ext→▲, ▼→ext)
+- Helpers: `add-sr-to-structure`, `open-add-sr-dialog`, `apply-sr-init-value`, `open-sr-edit-dialog`
+- `canvas-delete-selected`: borra SR + todos sus wires internos y externos
+- `on-down` prioridad 2.5: crea wires SR (validación de tipo, dirección)
+- `on-up`: completa wires SR
+- `on-dbl-click` priority 0: editar init-value de SR
+- `open-palette` con botón "Add SR"
+**Tests:** 208/208 PASS (solo render, sin tests de render puro)
+
+### 2026-03-24 — Phase 10 completada (compilador SR)
+**Implementado en compiler.red:**
+- `build-sorted-items`: topo-sort unificado de nodos + estructuras, usando IDs externos de wires SR
+- `compile-structure` actualizado: nueva firma `[st outer-diagram]`
+  - Inicialización de SRs antes del `until` (literal o variable de nodo fuente externo)
+  - Actualización de SRs dentro del `until` (antes del incremento de iteración)
+- `compile-body` actualizado: usa `build-sorted-items`, maneja nodos y estructuras en un solo loop
+- `compile-diagram` actualizado: usa `build-sorted-items`, elimina bloque "Añadir estructuras" separado
+- `test-compiler.red` actualizado: 3 llamadas a `compile-structure` actualizadas con `empty-outer`
+**Tests:** 208/208 PASS
+
+### 2026-03-24 — Phase 11 completada (serialización SR en file-io)
+**Implementado en file-io.red:**
+- `serialize-diagram`: añade bloque `shift-registers: [sr [...] sr [...]]` en cada estructura
+- `format-qvi`: formatea `shift-registers:` con indentación correcta (omitido si vacío)
+- `load-vi`: parsea `sr [...]` y reconstruye con `make-shift-register`, sincroniza names
+- Wires externos SR se serializan automáticamente (están en `diagram/wires`)
+- 15 tests nuevos en test-compiler.red (suite "file-io — round-trip shift registers")
+**Tests:** 223/223 PASS
+
+### 2026-03-24 — Phase 12 completada + Issue #14 CERRADO
+**Implementado:**
+- `make-node` en model.red: carga `config` desde spec (habilita round-trip de valores de constantes)
+- `serialize-nodes` en file-io.red: incluye `config:` en el bloque si no está vacío
+- `compile-diagram` en compiler.red: indicadores conectados a SR-right encuentran la variable `_sr_name`
+- `topological-sort`: ignorar wires con `to-node < 0` (fix para SR-right virtual en sub-diagramas)
+- Tests 12.2-12.4 (SR init, múltiples SRs, SR con wire externo) + test config round-trip
+- `examples/while-loop-suma.qvi`: suma 0+1+...+9 = 45 usando SR — funciona headless y UI
+**Tests:** 241/241 PASS

--- a/src/compiler/compiler.red
+++ b/src/compiler/compiler.red
@@ -297,8 +297,9 @@ node-string-input?: func [node /local bdef] [
 compile-structure: func [
     st           [object!]
     outer-diagram [object!]
-    /local iter-sym sub-diag sorted code until-body node bdef cond-expr cond-node
-           sr sr-sym init-val w src src-node
+    /no-gui       ; omite do-events/no-wait (modo headless — sin View)
+    /local iter-sym sub-diag sorted code loop-body until-body node bdef cond-expr cond-node
+           sr sr-sym init-val w src src-node n-sym n-val
 ][
     iter-sym: to-word rejoin ["_" st/name "_i"]
 
@@ -309,6 +310,95 @@ compile-structure: func [
     ]
 
     code: copy []
+
+    ; ── FOR-LOOP: compila a loop N [...] ───────────────────────
+    if st/type = 'for-loop [
+        ; Resolver wire de N obligatorio desde outer-diagram/wires
+        n-sym: to-word rejoin ["_" st/name "_N"]
+        n-val: none
+        foreach w outer-diagram/wires [
+            if all [w/to-node = st/id  w/to-port = 'count] [
+                foreach src outer-diagram/nodes [
+                    if src/id = w/from-node [
+                        n-val: port-var src to-word w/from-port
+                    ]
+                ]
+            ]
+        ]
+        if none? n-val [
+            print rejoin ["ERROR: For Loop '" st/name "' — terminal N no conectado (obligatorio)"]
+            return copy []
+        ]
+
+        ; Init N (to-integer: controles producen float!, loop requiere integer!)
+        append code to-set-word n-sym
+        append code 'to-integer
+        append code n-val
+
+        ; Init SRs (mismo patrón que while-loop)
+        foreach sr st/shift-regs [
+            sr-sym:   to-word rejoin ["_" sr/name]
+            init-val: sr/init-value
+            foreach w outer-diagram/wires [
+                if all [w/to-node = st/id  (to-word w/to-port) = to-word sr/name] [
+                    foreach src outer-diagram/nodes [
+                        if src/id = w/from-node [
+                            init-val: port-var src to-word w/from-port
+                        ]
+                    ]
+                ]
+            ]
+            append code to-set-word sr-sym
+            append code init-val
+        ]
+
+        ; Init contador de iteración
+        append code to-set-word iter-sym
+        append code 0
+
+        ; Compilar cuerpo interno
+        loop-body: copy []
+        sorted: either empty? st/nodes [copy []] [topological-sort sub-diag]
+        foreach node sorted [
+            bdef: find-block node/type
+            if all [bdef  bdef/emit] [
+                append loop-body bind-emit bdef/emit (build-bindings node sub-diag bdef)
+            ]
+        ]
+
+        ; Actualización de SRs
+        foreach sr st/shift-regs [
+            sr-sym: to-word rejoin ["_" sr/name]
+            foreach w st/wires [
+                if all [w/to-node = -2  (to-word w/to-port) = to-word sr/name] [
+                    foreach src-node st/nodes [
+                        if src-node/id = w/from-node [
+                            append loop-body to-set-word sr-sym
+                            append loop-body port-var src-node to-word w/from-port
+                        ]
+                    ]
+                ]
+            ]
+        ]
+
+        ; Incrementar _i
+        append loop-body to-set-word iter-sym
+        append loop-body iter-sym
+        append loop-body to-word "+"
+        append loop-body 1
+
+        ; GUI responsiva (DT-027) — solo en modo UI (no en headless)
+        unless no-gui [append/only loop-body to-path [do-events no-wait]]
+
+        ; loop N [body]
+        append code 'loop
+        append code n-sym
+        append/only code loop-body
+
+        return code
+    ]
+
+    ; ── WHILE-LOOP: compila a until [...] ──────────────────────
 
     ; ── Inicialización de shift registers ──────────────────────
     foreach sr st/shift-regs [
@@ -365,7 +455,8 @@ compile-structure: func [
 
     ; Ceder control a la GUI una vez por iteración (DT-027 Fase 2)
     ; do-events/no-wait: procesa eventos pendientes y vuelve inmediatamente
-    append/only until-body to-path [do-events no-wait]
+    ; Solo en modo UI — en headless no hay View y do-events cuelga
+    unless no-gui [append/only until-body to-path [do-events no-wait]]
 
     ; Condición final (última expresión del until)
     cond-expr: either st/cond-wire [
@@ -403,9 +494,9 @@ compile-body: func [
     code: copy []
     foreach item sorted [
         either in item 'shift-regs [
-            ; Estructura (while-loop u otra)
-            if item/type = 'while-loop [
-                append code compile-structure item diagram
+            ; Estructura — headless: sin do-events/no-wait
+            if find [while-loop for-loop] item/type [
+                append code compile-structure/no-gui item diagram
             ]
         ][
             ; Nodo normal
@@ -441,8 +532,8 @@ compile-diagram: func [
     run-body: copy []
     foreach item sorted [
         either in item 'shift-regs [
-            ; Estructura while-loop
-            if item/type = 'while-loop [
+            ; Estructura — modo GUI: con do-events/no-wait
+            if find [while-loop for-loop] item/type [
                 append run-body compile-structure item diagram
             ]
         ][

--- a/src/graph/blocks.red
+++ b/src/graph/blocks.red
@@ -252,10 +252,16 @@ block 'while-loop 'structure [
     ;   cond     — condición, entrada 'boolean desde nodo interno
 ]
 
+block 'for-loop 'structure [
+    ; Terminales:
+    ;   N    — cuenta de iteraciones, entrada 'number desde nodo EXTERNO (obligatorio)
+    ;   i    — iteración 0-based, salida 'number hacia nodos internos
+]
+
 ; Terminal de iteración como bloque virtual (para type-check al cablear)
 block 'iter 'structure-virtual [
     out i 'number
-    ; sin emit: la variable _while_N_i ya la genera compile-structure
+    ; sin emit: la variable _X_N_i ya la genera compile-structure
 ]
 
 #include %../compiler/compiler.red

--- a/src/graph/model.red
+++ b/src/graph/model.red
@@ -288,7 +288,8 @@ make-structure: func [
     s/label: case [
         block? lbl-spec  [make-label lbl-spec]
         string? lbl-spec [make-label compose [text: (lbl-spec) visible: (true)]]
-        true             [make-label compose [text: "While Loop" visible: (true) offset: 0x-15]]
+        s/type = 'for-loop [make-label compose [text: "For Loop"  visible: (true) offset: 0x-15]]
+        true               [make-label compose [text: "While Loop" visible: (true) offset: 0x-15]]
     ]
     s
 ]

--- a/src/io/file-io.red
+++ b/src/io/file-io.red
@@ -65,15 +65,14 @@ serialize-diagram: func [
     nodes-block:  serialize-nodes  diagram/nodes
     wires-block:  serialize-wires  diagram/wires
 
-    ; ── Structures (while-loop) ────────────────────────────────────
+    ; ── Structures (while-loop, for-loop) ──────────────────────────────
     structs-block: copy []
     if all [object? diagram  in diagram 'structures  block? diagram/structures] [
         foreach st diagram/structures [
-            lbl-block: either all [st/label  object? st/label] [
-                compose [text: (st/label/text)  visible: (st/label/visible)]
-            ][
-                compose [text: "While Loop"  visible: (true)]
+            lbl-text: either all [st/label  object? st/label] [st/label/text] [
+                either st/type = 'for-loop ["For Loop"] ["While Loop"]
             ]
+            lbl-block: compose [text: (lbl-text)  visible: (true)]
             ; Shift registers
             sr-block: copy []
             foreach sr st/shift-regs [
@@ -86,20 +85,31 @@ serialize-diagram: func [
             ; Nodos internos: coords RELATIVAS a la estructura
             st-nodes-block: serialize-nodes/relative st/nodes st/x st/y
             st-wires-block: serialize-wires st/wires
-            ; Wire de condición
-            cond-spec: either st/cond-wire [
-                compose [from: (st/cond-wire/from)  port: (st/cond-wire/port)]
+            ; Keyword de estructura según tipo
+            append structs-block st/type
+            ; Bloque de datos: condition solo para while-loop
+            either st/type = 'for-loop [
+                append/only structs-block compose/only [
+                    id: (st/id)  name: (st/name)  label: (lbl-block)
+                    x: (st/x)  y: (st/y)  w: (st/w)  h: (st/h)
+                    shift-registers: (sr-block)
+                    nodes: (st-nodes-block)
+                    wires: (st-wires-block)
+                ]
             ][
-                none
-            ]
-            append structs-block 'while-loop
-            append/only structs-block compose/only [
-                id: (st/id)  name: (st/name)  label: (lbl-block)
-                x: (st/x)  y: (st/y)  w: (st/w)  h: (st/h)
-                shift-registers: (sr-block)
-                condition: (either cond-spec [cond-spec] [[]])
-                nodes: (st-nodes-block)
-                wires: (st-wires-block)
+                cond-spec: either st/cond-wire [
+                    compose [from: (st/cond-wire/from)  port: (st/cond-wire/port)]
+                ][
+                    none
+                ]
+                append/only structs-block compose/only [
+                    id: (st/id)  name: (st/name)  label: (lbl-block)
+                    x: (st/x)  y: (st/y)  w: (st/w)  h: (st/h)
+                    shift-registers: (sr-block)
+                    condition: (either cond-spec [cond-spec] [[]])
+                    nodes: (st-nodes-block)
+                    wires: (st-wires-block)
+                ]
             ]
         ]
     ]
@@ -169,7 +179,7 @@ format-qvi: func [
     if all [structs-raw  not empty? structs-raw] [
         parse structs-raw [
             any [
-                'while-loop set struct-block block! (
+                set struct-kw ['while-loop | 'for-loop] set struct-block block! (
                     st-nodes-raw: any [select struct-block 'nodes  []]
                     st-wires-raw: any [select struct-block 'wires  []]
                     st-srs-raw:   any [select struct-block 'shift-registers  []]
@@ -198,7 +208,7 @@ format-qvi: func [
                         ]
                     ]
                     append structs-str rejoin [
-                        "        while-loop [^/"
+                        "        " form struct-kw " [^/"
                         "            id: " mold any [select struct-block 'id  0]
                         "  name: " mold any [select struct-block 'name  ""]
                         "  label: " mold any [select struct-block 'label  []] "^/"
@@ -209,7 +219,10 @@ format-qvi: func [
                         either empty? st-srs-str [""] [rejoin [
                             "            shift-registers: [^/" st-srs-str "            ]^/"
                         ]]
-                        "            condition: " mold any [select struct-block 'condition  []] "^/"
+                        ; condition solo en while-loop
+                        either struct-kw = 'while-loop [
+                            rejoin ["            condition: " mold any [select struct-block 'condition  []] "^/"]
+                        ][""]
                         "            nodes: [^/" st-nodes-str "            ]^/"
                         "            wires: [^/" st-wires-str "            ]^/"
                         "        ]^/"
@@ -431,19 +444,20 @@ load-vi: func [
     if nodes-data  [d/nodes: load-node-list nodes-data names]
     if wires-data  [d/wires: load-wire-list wires-data]
 
-    ; ── Cargar structures (while-loop) ────────────────────────────
+    ; ── Cargar structures (while-loop, for-loop) ──────────────────
     if all [structs-data  block? structs-data] [
         parse structs-data [
             any [
-                'while-loop set st-spec block! (
+                set st-kw ['while-loop | 'for-loop] set st-spec block! (
                     st: make-structure compose [
-                        id: (any [select st-spec 'id  0])
-                        name: (any [select st-spec 'name  ""])
-                        x: (any [select st-spec 'x  0])
-                        y: (any [select st-spec 'y  0])
-                        w: (any [select st-spec 'w  300])
-                        h: (any [select st-spec 'h  200])
-                        label: (any [select st-spec 'label  [text: "While Loop"]])
+                        id:   (any [select st-spec 'id   0])
+                        type: (st-kw)
+                        name: (any [select st-spec 'name ""])
+                        x:    (any [select st-spec 'x    0])
+                        y:    (any [select st-spec 'y    0])
+                        w:    (any [select st-spec 'w    300])
+                        h:    (any [select st-spec 'h    200])
+                        label: (any [select st-spec 'label  compose [text: (either st-kw = 'for-loop ["For Loop"] ["While Loop"])]])
                     ]
                     ; Shift registers
                     sr-data: any [select st-spec 'shift-registers  []]
@@ -468,15 +482,17 @@ load-vi: func [
                     ; Wires internos
                     st-wires: any [select st-spec 'wires  []]
                     st/wires: load-wire-list st-wires
-                    ; Wire de condición
-                    cond-data: select st-spec 'condition
-                    st/cond-wire: either all [cond-data  not empty? cond-data] [
-                        make object! [
-                            from: any [select cond-data 'from  0]
-                            port: any [select cond-data 'port  'result]
+                    ; Wire de condición solo para while-loop
+                    if st-kw = 'while-loop [
+                        cond-data: select st-spec 'condition
+                        st/cond-wire: either all [cond-data  not empty? cond-data] [
+                            make object! [
+                                from: any [select cond-data 'from  0]
+                                port: any [select cond-data 'port  'result]
+                            ]
+                        ][
+                            none
                         ]
-                    ][
-                        none
                     ]
                     if st/name [append names st/name]
                     append d/structures st

--- a/src/ui/diagram/canvas.red
+++ b/src/ui/diagram/canvas.red
@@ -371,10 +371,23 @@ render-structure: func [
         text (as-pair (bx + 11) (by2 - tx - 5)) "i"
     ]
 
-    ; 4) Terminal condición [●] — círculo verde abajo-derecha
-    append cmds compose [
-        pen (col-struct-border)  line-width 1  fill-pen (col-struct-term-cond)
-        circle (as-pair (bx2 - 16) (by2 - 16)) 8
+    ; 4) Terminal condición [●] — círculo verde abajo-derecha (solo while-loop)
+    if st/type = 'while-loop [
+        append cmds compose [
+            pen (col-struct-border)  line-width 1  fill-pen (col-struct-term-cond)
+            circle (as-pair (bx2 - 16) (by2 - 16)) 8
+        ]
+    ]
+
+    ; 4b) Terminal count [N] — cuadrado naranja arriba-izquierda (solo for-loop)
+    if st/type = 'for-loop [
+        append cmds compose [
+            pen (col-struct-border)  line-width 1  fill-pen (col-wire)
+            box (as-pair (bx + 8) (by + 8))
+                (as-pair (bx + 8 + tx) (by + 8 + tx)) 2
+            pen off  fill-pen col-text
+            text (as-pair (bx + 11) (by + 11)) "N"
+        ]
     ]
 
     ; 5) Terminales shift register — ▲ borde izquierdo, ▼ borde derecho
@@ -544,10 +557,30 @@ render-bd: func [model /local cmds src-port-xy mid st] [
     ; 2) Wires permanentes normales
     append cmds render-wire-list model/wires model/nodes model/selected-wire
 
-    ; 2b) Wires externos de shift registers (ext→▲ y ▼→ext)
+    ; 2b) Wires externos de shift registers (ext→▲ y ▼→ext) y wire N de for-loop
     if block? model/structures [
         foreach _sst model/structures [
             foreach _sw model/wires [
+                ; For-loop: External → [N] (to-node = structure ID, to-port = "count")
+                if all [_sst/type = 'for-loop  _sw/to-node = _sst/id  _sw/to-port = 'count] [
+                    do [
+                        _snd: none
+                        foreach _nd model/nodes [if _nd/id = _sw/from-node [_snd: _nd]]
+                        if _snd [
+                            _sout: port-xy _snd _sw/from-port 'out
+                            _htx: to-integer (struct-terminal-size / 2)
+                            _ndst: as-pair (to-integer _sst/x + 8 + _htx)
+                                           (to-integer _sst/y + 8 + _htx)
+                            _smx: to-integer (_sout/x + _ndst/x) / 2
+                            append cmds compose [
+                                pen (col-wire)  line-width 2
+                                line (_sout) (as-pair _smx _sout/y)
+                                     (as-pair _smx _ndst/y) (_ndst)
+                                line-width 1
+                            ]
+                        ]
+                    ]
+                ]
                 ; External → SR-left (to-node = structure ID)
                 if _sw/to-node = _sst/id [
                     do [
@@ -686,21 +719,30 @@ hit-structure-node: func [model mouse-x mouse-y /local st node] [
 ; Devuelve [struct 'cond|'iter] si el punto cae sobre un terminal, o none.
 ; 'iter = terminal iteración [i] abajo-izquierda
 ; 'cond = terminal condición [●] abajo-derecha
-hit-structure-terminal: func [model mouse-x mouse-y /local st bx by2 bx2 tx tol] [
+hit-structure-terminal: func [model mouse-x mouse-y /local st bx by by2 bx2 tx tol] [
     tol: 8
     foreach st model/structures [
-        bx: st/x  by2: st/y + st/h  bx2: st/x + st/w
+        bx: st/x  by: st/y  by2: st/y + st/h  bx2: st/x + st/w
         tx: struct-terminal-size
-        ; Terminal iteración: cuadrado (bx+8, by2-tx-8) → (bx+8+tx, by2-8)
+        ; Terminal iteración [i]: cuadrado (bx+8, by2-tx-8) → (bx+8+tx, by2-8) — ambos tipos
         if all [
             mouse-x >= (bx + 8 - tol)  mouse-x <= (bx + 8 + tx + tol)
             mouse-y >= (by2 - tx - 8 - tol)  mouse-y <= (by2 - 8 + tol)
         ] [return reduce [st 'iter]]
-        ; Terminal condición: círculo en (bx2-16, by2-16) radio 8
-        if all [
-            (absolute (mouse-x - (bx2 - 16))) <= (8 + tol)
-            (absolute (mouse-y - (by2 - 16))) <= (8 + tol)
-        ] [return reduce [st 'cond]]
+        ; Terminal condición [●]: círculo en (bx2-16, by2-16) radio 8 — solo while-loop
+        if st/type = 'while-loop [
+            if all [
+                (absolute (mouse-x - (bx2 - 16))) <= (8 + tol)
+                (absolute (mouse-y - (by2 - 16))) <= (8 + tol)
+            ] [return reduce [st 'cond]]
+        ]
+        ; Terminal count [N]: cuadrado (bx+8, by+8) → (bx+8+tx, by+8+tx) — solo for-loop
+        if st/type = 'for-loop [
+            if all [
+                mouse-x >= (bx + 8 - tol)  mouse-x <= (bx + 8 + tx + tol)
+                mouse-y >= (by + 8 - tol)   mouse-y <= (by + 8 + tx + tol)
+            ] [return reduce [st 'count]]
+        ]
     ]
     none
 ]
@@ -997,10 +1039,10 @@ palette-add-node: func [node-type /local n nid model] [
 ]
 
 ; Crea una nueva estructura while-loop y la añade al diagrama.
-palette-add-structure: func [/local nid st model] [
+palette-add-structure: func [type [word!] /local nid st model] [
     model: palette-canvas/extra
     nid: gen-node-id model
-    st: make-structure compose [id: (nid) x: (palette-pos-x) y: (palette-pos-y)]
+    st: make-structure compose [id: (nid) type: (type) x: (palette-pos-x) y: (palette-pos-y)]
     append model/structures st
     palette-canvas/draw: render-bd model
     show palette-canvas
@@ -1037,7 +1079,8 @@ open-palette: func [face x y /struct target-struct] [
         button 80 "Len"      [palette-add-node 'str-length]
         button 80 "→STR"     [palette-add-node 'to-string]      return
         text "Estructuras:"  return
-        button 80 "While"    [palette-add-structure]             return
+        button 80 "While"    [palette-add-structure 'while-loop]
+        button 80 "For"      [palette-add-structure 'for-loop]   return
         button 80 "Add SR"   [
             if palette-struct [
                 unview
@@ -1202,6 +1245,12 @@ canvas-delete-selected: func [canvas /local model node-id node-name node-type st
     ; Estructura completa seleccionada (borde, sin nodo seleccionado)
     if model/selected-struct [
         st: model/selected-struct
+        ; Limpiar wire de N si es for-loop
+        if st/type = 'for-loop [
+            remove-each w model/wires [
+                all [w/to-node = st/id  w/to-port = 'count]
+            ]
+        ]
         remove-each s model/structures [same? s st]
         model/selected-struct: none
         canvas/draw: render-bd model
@@ -1423,7 +1472,7 @@ render-diagram: func [model canvas-width canvas-height /local canvas-face] [
                         return none
                     ]
 
-                    ; Si hay wire-src activo + terminal condición → conectar
+                    ; Si hay wire-src activo + terminal condición → conectar (while-loop)
                     if all [model/wire-src  hit-result/2 = 'cond] [
                         either (port-out-type model/wire-src model/wire-port) = 'boolean [
                             ; Guardar cond-wire en la estructura
@@ -1438,6 +1487,34 @@ render-diagram: func [model canvas-width canvas-height /local canvas-face] [
                                 port-xy model/wire-src model/wire-port 'out
                                 as-pair (hit-result/1/x + hit-result/1/w - 16)
                                         (hit-result/1/y + hit-result/1/h - 16)
+                            ]
+                        ]
+                        model/wire-src: none  model/wire-port: none  model/mouse-pos: none  model/wire-src-struct: none  model/wire-src-sr: none
+                        face/draw: render-bd model
+                        return none
+                    ]
+                    ; Si hay wire-src activo + terminal [N] → conectar (for-loop, externo)
+                    if all [model/wire-src  hit-result/2 = 'count] [
+                        do [
+                            _fst: hit-result/1
+                            _htx: to-integer (struct-terminal-size / 2)
+                            _ndst: as-pair (to-integer _fst/x + 8 + _htx)
+                                           (to-integer _fst/y + 8 + _htx)
+                            either (port-out-type model/wire-src model/wire-port) = 'number [
+                                ; Eliminar wire previo de N si existía
+                                remove-each _w model/wires [
+                                    all [_w/to-node = _fst/id  _w/to-port = 'count]
+                                ]
+                                append model/wires make-wire compose [
+                                    from: (model/wire-src/id)  from-port: (model/wire-port)
+                                    to: (_fst/id)  to-port: "count"
+                                ]
+                                model/broken-wire: none
+                            ][
+                                model/broken-wire: reduce [
+                                    port-xy model/wire-src model/wire-port 'out
+                                    _ndst
+                                ]
                             ]
                         ]
                         model/wire-src: none  model/wire-port: none  model/mouse-pos: none  model/wire-src-struct: none  model/wire-src-sr: none

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,4 +1,11 @@
-# Task Plan — Issue #14: While Loop
+# Task Plan — Issue #15: For Loop — COMPLETADO ✅
+
+Tests finales: 271/271 PASS
+Ver progress.md para detalles.
+
+---
+
+# Task Plan histórico — Issue #14: While Loop
 
 ## Meta
 | Campo | Valor |
@@ -169,13 +176,13 @@ En el sort principal: cada structure es un **nodo virtual**.
 - Dentro del until: topological sort del sub-diagrama (structure/nodes + structure/wires)
 
 ### Tasks
-- [ ] 4.1 `compile-structure` — genera bloque `until [...]` para while-loop
-- [ ] 4.2 Topological sort del sub-diagrama
-- [ ] 4.3 Inyectar terminal iteración (_while_M_i: 0, incremento)
-- [ ] 4.4 Resolver terminal condición como última expresión del until
-- [ ] 4.5 Caso borde: condición no conectada → `true` (ejecuta una vez)
-- [ ] 4.6 Integrar en `compile-body`: structures se compilan con nodos normales
-- [ ] 4.7 Integrar en `compile-diagram` (run-body del botón Run)
+- [x] 4.1 `compile-structure` — genera bloque `until [...]` para while-loop
+- [x] 4.2 Topological sort del sub-diagrama
+- [x] 4.3 Inyectar terminal iteración (_while_M_i: 0, incremento)
+- [x] 4.4 Resolver terminal condición como última expresión del until
+- [x] 4.5 Caso borde: condición no conectada → `true` (ejecuta una vez)
+- [x] 4.6 Integrar en `compile-body`: structures se compilan con nodos normales
+- [x] 4.7 Integrar en `compile-diagram` (run-body del botón Run)
 
 ---
 
@@ -206,10 +213,10 @@ block-diagram: [
 ```
 
 ### Tasks
-- [ ] 5.1 `serialize-diagram`: incluir `structures:` con nodos internos en coords relativas
-- [ ] 5.2 `load-vi`: parsear `structures:`, reconstruir con make-structure, convertir coords relativas → absolutas
-- [ ] 5.3 `format-qvi`: formatear structures en .qvi multi-línea
-- [ ] 5.4 Test round-trip: save → load → save
+- [x] 5.1 `serialize-diagram`: incluir `structures:` con nodos internos en coords relativas
+- [x] 5.2 `load-vi`: parsear `structures:`, reconstruir con make-structure, convertir coords relativas → absolutas
+- [x] 5.3 `format-qvi`: formatear structures en .qvi multi-línea
+- [x] 5.4 Test round-trip: save → load → save
 
 ---
 
@@ -218,13 +225,13 @@ block-diagram: [
 **Módulos:** tests/, examples/
 
 ### Tasks
-- [ ] 6.1 Tests modelo: make-structure, fields, defaults
-- [ ] 6.2 Tests compilador: while-loop con condición → until correcto
-- [ ] 6.3 Tests compilador: terminal iteración accesible
-- [ ] 6.4 Tests compilador: condición no conectada → true
-- [ ] 6.5 Tests file-io: round-trip con structures
-- [ ] 6.6 Ejemplo: `examples/while-loop-basico.qvi` — cuenta de 0 a 9
-- [ ] 6.7 Verificación visual manual
+- [x] 6.1 Tests modelo: make-structure, fields, defaults
+- [x] 6.2 Tests compilador: while-loop con condición → until correcto
+- [x] 6.3 Tests compilador: terminal iteración accesible
+- [x] 6.4 Tests compilador: condición no conectada → true
+- [x] 6.5 Tests file-io: round-trip con structures
+- [x] 6.6 Ejemplo: `examples/while-loop-basico.qvi` — cuenta de 0 a 9
+- [x] 6.7 Verificación visual manual
 
 ---
 
@@ -278,9 +285,9 @@ structure/shift-regs: [sr-object-1  sr-object-2  ...]
 Convención IDs negativos: -1 = SR-left virtual, -2 = SR-right virtual, -3 = iteración virtual.
 
 ### Tasks
-- [ ] 7.1 `make-shift-register` en model.red
-- [ ] 7.2 Añadir `shift-regs: copy []` a make-structure
-- [ ] 7.3 Definir convención de wires a/desde SRs (IDs virtuales o campo especial)
+- [x] 7.1 `make-shift-register` en model.red
+- [x] 7.2 Añadir `shift-regs: copy []` a make-structure
+- [x] 7.3 Definir convención de wires a/desde SRs (IDs virtuales o campo especial)
 
 ---
 
@@ -305,9 +312,9 @@ Color = según data-type del SR (naranja number, verde bool, rosa string)
 ```
 
 ### Tasks
-- [ ] 8.1 Renderizar terminales SR (▲ izq, ▼ der) en los bordes
-- [ ] 8.2 Renderizar wires externos a/desde SRs
-- [ ] 8.3 Texto con init-value cuando SR no tiene wire conectado
+- [x] 8.1 Renderizar terminales SR (▲ izq, ▼ der) en los bordes
+- [x] 8.2 Renderizar wires externos a/desde SRs
+- [x] 8.3 Texto con init-value cuando SR no tiene wire conectado
 
 ---
 
@@ -316,20 +323,20 @@ Color = según data-type del SR (naranja number, verde bool, rosa string)
 **Módulos:** canvas.red
 
 ### Tasks
-- [ ] 9.1 Hit-test en terminales SR (▲/▼)
-- [ ] 9.2 Wire externo → SR-left (clic en puerto de nodo externo → clic en ▲)
-- [ ] 9.3 Wire SR-right → externo (clic en ▼ → clic en puerto de nodo externo)
-- [ ] 9.4 Wire interno desde SR-left (clic en ▲ interior → nodo interno)
-- [ ] 9.5 Wire interno a SR-right (nodo interno → clic en ▼ interior)
-- [ ] 9.6 Añadir SR: botón en menú/paleta o doble clic en borde
-- [ ] 9.7 Borrar SR: delete cuando SR seleccionado + limpiar wires asociados
-- [ ] 9.8 Doble clic en SR: editar valor inicial (diálogo)
-- [ ] 9.9 Type guard: wire a SR valida tipo compatible
+- [x] 9.1 Hit-test en terminales SR (▲/▼)
+- [x] 9.2 Wire externo → SR-left (clic en puerto de nodo externo → clic en ▲)
+- [x] 9.3 Wire SR-right → externo (clic en ▼ → clic en puerto de nodo externo)
+- [x] 9.4 Wire interno desde SR-left (clic en ▲ interior → nodo interno)
+- [x] 9.5 Wire interno a SR-right (nodo interno → clic en ▼ interior)
+- [x] 9.6 Añadir SR: botón en menú/paleta o doble clic en borde
+- [x] 9.7 Borrar SR: delete cuando SR seleccionado + limpiar wires asociados
+- [x] 9.8 Doble clic en SR: editar valor inicial (diálogo)
+- [x] 9.9 Type guard: wire a SR valida tipo compatible
 
 ---
 
 ## Phase 10 — Compilador con shift registers
-**Estado:** pending
+**Estado:** complete
 **Módulos:** compiler.red
 
 ### Generación de código
@@ -360,16 +367,16 @@ Con shift registers, la structure tiene dependencias externas:
 - La structure participa en el sort principal como nodo virtual con in-degree/out-degree
 
 ### Tasks
-- [ ] 10.1 Inicialización de SRs antes del until
-- [ ] 10.2 Resolver bindings: SR-left como fuente, SR-right como destino
-- [ ] 10.3 Actualizar SRs dentro del until (wires internos → SR-right)
-- [ ] 10.4 Topological sort: structure con dependencias externas (wires a/desde SRs)
-- [ ] 10.5 Nodos externos leen SRs tras el loop
+- [x] 10.1 Inicialización de SRs antes del until
+- [x] 10.2 Resolver bindings: SR-left como fuente, SR-right como destino
+- [x] 10.3 Actualizar SRs dentro del until (wires internos → SR-right)
+- [x] 10.4 Topological sort: structure con dependencias externas (wires a/desde SRs)
+- [x] 10.5 Nodos externos leen SRs tras el loop
 
 ---
 
 ## Phase 11 — Serialización de shift registers
-**Estado:** pending
+**Estado:** complete
 **Módulos:** file-io.red
 
 ### Formato qvi-diagram extendido
@@ -390,24 +397,24 @@ structures: [
 ```
 
 ### Tasks
-- [ ] 11.1 Serializar shift-registers dentro de la estructura
-- [ ] 11.2 Cargar shift-registers desde qvi-diagram
-- [ ] 11.3 Serializar wires externos a/desde SRs (en diagram/wires con to/from: structure-id)
-- [ ] 11.4 Test round-trip con SRs
+- [x] 11.1 Serializar shift-registers dentro de la estructura
+- [x] 11.2 Cargar shift-registers desde qvi-diagram
+- [x] 11.3 Serializar wires externos a/desde SRs (en diagram/wires con to/from: structure-id)
+- [x] 11.4 Test round-trip con SRs
 
 ---
 
 ## Phase 12 — Tests y ejemplo con shift registers
-**Estado:** pending
+**Estado:** complete
 
 ### Tasks
-- [ ] 12.1 Tests: make-shift-register, fields
-- [ ] 12.2 Tests compilador: SR inicialización + actualización
-- [ ] 12.3 Tests compilador: múltiples SRs
-- [ ] 12.4 Tests compilador: SR con wire externo (valor inicial dinámico)
-- [ ] 12.5 Tests file-io: round-trip con SRs
-- [ ] 12.6 Ejemplo: `examples/while-loop-suma.qvi` — suma acumulativa 1 a 10 con SR
-- [ ] 12.7 Verificación visual manual
+- [x] 12.1 Tests: make-shift-register, fields
+- [x] 12.2 Tests compilador: SR inicialización + actualización
+- [x] 12.3 Tests compilador: múltiples SRs
+- [x] 12.4 Tests compilador: SR con wire externo (valor inicial dinámico)
+- [x] 12.5 Tests file-io: round-trip con SRs
+- [x] 12.6 Ejemplo: `examples/while-loop-suma.qvi` — suma acumulativa 1 a 10 con SR
+- [x] 12.7 Verificación visual manual
 
 ---
 

--- a/tests/test-blocks.red
+++ b/tests/test-blocks.red
@@ -4,7 +4,7 @@ do %../src/graph/blocks.red
 
 suite "blocks — registro"
 
-assert "registra 25 bloques (8 originales + 9 booleanos + 6 string + 2 estructura+virtual)" (25 = length? block-registry)
+assert "registra 26 bloques (8 originales + 9 booleanos + 6 string + 3 estructura+virtual)" (26 = length? block-registry)
 assert "const está en el registro"     (not none? find-block 'const)
 assert "add está en el registro"       (not none? find-block 'add)
 assert "find-block devuelve none para bloques inexistentes" (none? find-block 'nonexistent)

--- a/tests/test-compiler.red
+++ b/tests/test-compiler.red
@@ -539,3 +539,107 @@ assert "config round-trip: nodo cargado"         (object? cfg-rt-ln)
 assert "config round-trip: name correcto"        ("cfg_c" = cfg-rt-ln/name)
 assert "config round-trip: config no vacío"      (not empty? cfg-rt-ln/config)
 assert "config round-trip: valor 42.0"           (42.0 = select cfg-rt-ln/config 'default)
+
+; ── Tests compile-structure (for-loop) ──────────────────────────────
+
+suite "compile-structure — for-loop sin wire N devuelve bloque vacío"
+
+reset-name-counters
+fl-empty-outer: make object! [nodes: copy []  wires: copy []  structures: copy []]
+fl-no-n: make-structure [id: 500  type: 'for-loop  name: "for-loop_no_n"  x: 0  y: 0]
+fl-no-n-code: compile-structure fl-no-n fl-empty-outer
+
+assert "sin N: código vacío (error)"             (empty? fl-no-n-code)
+
+suite "compile-structure — for-loop básico con N=5"
+
+reset-name-counters
+; Diagrama externo con nodo const N=5
+fl-diag: make-diagram "fl-vi"
+fl-n-nd: make-node [id: 600  type: 'const  name: "n_val"  x: 0  y: 0]
+fl-n-nd/config: reduce ['default 5.0]
+append fl-diag/nodes fl-n-nd
+
+; Estructura for-loop
+fl-st: make-structure [id: 601  type: 'for-loop  name: "for-loop_1"  x: 100  y: 100]
+append fl-diag/structures fl-st
+
+; Wire externo: n_val/result → fl-st/count
+append fl-diag/wires make-wire [from: 600  from-port: 'result  to: 601  to-port: "count"]
+
+fl-code: compile-structure fl-st fl-diag
+
+; Verificar estructura del código generado
+fl-n-sw:  find fl-code to-set-word '_for-loop_1_N
+fl-i-sw:  find fl-code to-set-word '_for-loop_1_i
+fl-loop-idx: index? find fl-code 'loop
+
+assert "N inicializado"                          (not none? fl-n-sw)
+assert "N usa to-integer"                        ('to-integer = fl-n-sw/2)
+assert "N referencia variable del nodo"          ('n_val_result = fl-n-sw/3)
+assert "_i inicializado a 0"                     (not none? fl-i-sw)
+assert "código contiene 'loop'"                  (not none? find fl-code 'loop)
+assert "'loop' sigue a N sym"                    (fl-loop-idx > (index? fl-n-sw))
+fl-loop-n-sym: fl-code/(fl-loop-idx + 1)
+fl-loop-body:  fl-code/(fl-loop-idx + 2)
+assert "loop recibe el sym de N"                 (fl-loop-n-sym = '_for-loop_1_N)
+assert "cuerpo del loop es un bloque"            (block? fl-loop-body)
+assert "cuerpo NO contiene 'until'"              (none? find fl-loop-body 'until)
+
+suite "compile-structure — for-loop: _i se incrementa dentro del loop"
+
+fl-i-inc: find fl-loop-body to-set-word '_for-loop_1_i
+assert "_i se incrementa en el body"             (not none? fl-i-inc)
+assert "incremento en 1"                         (1 = fl-i-inc/4)
+
+suite "compile-structure — for-loop con SR"
+
+reset-name-counters
+fl-sr-diag: make-diagram "fl-sr-vi"
+fl-sr-n-nd: make-node [id: 700  type: 'const  name: "fl_n"  x: 0  y: 0]
+fl-sr-n-nd/config: reduce ['default 10.0]
+append fl-sr-diag/nodes fl-sr-n-nd
+
+fl-sr-st: make-structure [id: 701  type: 'for-loop  name: "for-loop_sr"  x: 100  y: 100]
+fl-sr: make-shift-register [id: 702  name: "fl_acc"  data-type: 'number  init-value: 0.0  y-offset: 40]
+append fl-sr-st/shift-regs fl-sr
+append fl-sr-diag/structures fl-sr-st
+
+append fl-sr-diag/wires make-wire [from: 700  from-port: 'result  to: 701  to-port: "count"]
+
+fl-sr-code: compile-structure fl-sr-st fl-sr-diag
+fl-sr-acc-sw: find fl-sr-code to-set-word '_fl_acc
+
+assert "SR acc inicializado"                     (not none? fl-sr-acc-sw)
+assert "SR acc init-value 0.0"                   (0.0 = fl-sr-acc-sw/2)
+assert "código contiene 'loop'"                  (not none? find fl-sr-code 'loop)
+
+suite "file-io — round-trip for-loop"
+
+reset-name-counters
+fl-rt-diag: make-diagram "fl-rt-vi"
+fl-rt-n-nd: make-node [id: 800  type: 'const  name: "fl_rt_n"  x: 50  y: 50]
+fl-rt-n-nd/config: reduce ['default 5.0]
+append fl-rt-diag/nodes fl-rt-n-nd
+
+fl-rt-st: make-structure [id: 801  type: 'for-loop  name: "for-loop_rt"  x: 100  y: 100]
+append fl-rt-diag/structures fl-rt-st
+append fl-rt-diag/wires make-wire [from: 800  from-port: 'result  to: 801  to-port: "count"]
+
+fl-rt-file: %/tmp/qtorres-fl-rt.qvi
+save-vi fl-rt-file fl-rt-diag
+fl-rt-loaded: load-vi fl-rt-file
+if exists? fl-rt-file [delete fl-rt-file]
+
+fl-rt-structs: fl-rt-loaded/structures
+assert "round-trip: estructura cargada"          (1 = length? fl-rt-structs)
+assert "round-trip: tipo for-loop"               ('for-loop = fl-rt-structs/1/type)
+assert "round-trip: name correcto"               ("for-loop_rt" = fl-rt-structs/1/name)
+assert "round-trip: label For Loop"              ("For Loop" = fl-rt-structs/1/label/text)
+; Wire de N en diagram/wires
+fl-rt-n-wire: none
+foreach w fl-rt-loaded/wires [
+    if all [w/to-node = 801  w/to-port = 'count] [fl-rt-n-wire: w]
+]
+assert "round-trip: wire N en diagram/wires"     (not none? fl-rt-n-wire)
+assert "round-trip: wire N from correcto"        (800 = fl-rt-n-wire/from-node)

--- a/tests/test-model.red
+++ b/tests/test-model.red
@@ -131,3 +131,27 @@ s6: make-structure []
 s7: make-structure []
 append s6/shift-regs make-shift-register []
 assert "shift-regs son independientes"          (0 = length? s7/shift-regs)
+
+; ── make-structure — for-loop ────────────────────────────────────────
+
+suite "make-structure — for-loop defaults"
+
+reset-name-counters
+sf: make-structure [type: 'for-loop]
+
+assert "for-loop tipo correcto"                 (sf/type = 'for-loop)
+assert "for-loop name generado"                 (sf/name = "for-loop_1")
+assert "for-loop label texto"                   (sf/label/text = "For Loop")
+assert "for-loop cond-wire none"                (none? sf/cond-wire)
+assert "for-loop shift-regs vacio"              (0 = length? sf/shift-regs)
+assert "for-loop w default 300"                 (sf/w = 300)
+assert "for-loop h default 200"                 (sf/h = 200)
+
+suite "make-structure — for-loop label independiente de while-loop"
+
+reset-name-counters
+sw: make-structure []
+sf2: make-structure [type: 'for-loop]
+
+assert "while label texto"                      (sw/label/text = "While Loop")
+assert "for label texto"                        (sf2/label/text = "For Loop")


### PR DESCRIPTION
## Summary

- Implementa el **For Loop** como segunda estructura contenedora del Block Diagram
- Terminal **[N]** externo obligatorio (wire de número, no compila sin él)
- Terminal **[i]** 0-based disponible como fuente interna
- Shift Registers reutilizados del While Loop
- Compilador genera `loop N [...]` — correcto para N=0 (no ejecuta), 0-based

## Cambios principales

| Fichero | Cambio |
|---------|--------|
| model.red | Label default por tipo ('For Loop' / 'While Loop') |
| blocks.red | Registra `'for-loop` como `'structure` |
| canvas.red | Render [N] naranja top-left, hit-test, wiring N, paleta, delete |
| compiler.red | `compile-structure` bifurcado; `loop N [...]`; refinamiento `/no-gui` |
| file-io.red | serialize/load/format-qvi soportan for-loop |
| tests/ | 30 tests nuevos — 271/271 PASS |
| examples/ | `for-loop-basico.qvi` — suma 0+1+...+9=45 |

## Bugs corregidos

- `make-wire` convierte `to-port` a `word!` — comparaciones cambiadas a `'count`
- `do-events/no-wait` en rama headless colgaba sin contexto View — refinamiento `/no-gui`
- `compile-body` y `compile-diagram` solo manejaban `'while-loop` — ahora manejan ambos tipos

## Test plan

- [x] Tests automatizados: 271/271 PASS
- [x] Paleta muestra "For Loop"
- [x] Terminal [N] rechaza booleanos, acepta números
- [x] Terminal [i] funciona como fuente interna
- [x] Drag, resize, delete
- [x] Shift Register: añadir, wirear, inicializar
- [x] Save / Load round-trip
- [x] Run con N=10 → 45 (suma acumulativa)
- [x] Run con N=0 → no ejecuta

## Bug conocido (no bloquea)

- **Bug #1:** Context menu "añadir SR" aparece en todo el área del For Loop, no solo en el borde

🤖 Generated with [Claude Code](https://claude.com/claude-code)