### PR TITLE
feat(#11): Array 1D — bloques, wires doble borde, FP control/indicator

### DIFF
--- a/src/compiler/compiler.red
+++ b/src/compiler/compiler.red
@@ -164,7 +164,12 @@ bind-emit: func [
         case [
             word? item [
                 v: select bindings item
-                append result either none? v [item] [v]
+                either none? v [
+                    append result item
+                ][
+                    ; /only para block! values (ej: array defaults) — evita aplanar
+                    either block? v [append/only result v] [append result v]
+                ]
             ]
             set-word? item [
                 k: to-word item
@@ -254,10 +259,20 @@ build-bindings: func [
         ; any [none false] = none en Red → usar either/none? explícito
         cfg-val: either none? select node/config cfg/name [cfg/default] [select node/config cfg/name]
         append bindings cfg/name
-        append bindings cfg-val
+        ; /only evita aplanar block! values (ej: array defaults como [1.0 2.0])
+        append/only bindings cfg-val
     ]
 
     bindings
+]
+
+; Devuelve true si el primer output del bloque es de tipo array.
+node-array-input?: func [node /local bdef] [
+    bdef: find-block to-word node/type
+    if all [bdef  not empty? bdef/outputs] [
+        return bdef/outputs/1/type = 'array
+    ]
+    false
 ]
 
 ; Devuelve true si el primer output del bloque es de tipo booleano.
@@ -542,16 +557,26 @@ compile-diagram: func [
             if none? bdef [continue]
             case [
                 bdef/category = 'input [
-                    face-sym: to-word rejoin ["f_" node/id]
                     case [
-                        node-boolean-input? node [
-                            append run-body compose [(to-set-word port-var node 'result) (to-path reduce [face-sym 'data])]
-                        ]
-                        node-string-input? node [
-                            append run-body compose [(to-set-word port-var node 'result) (to-path reduce [face-sym 'text])]
+                        node-array-input? node [
+                            ; Array control: valor fijo del config (no hay field editable — DT-028)
+                            if bdef/emit [
+                                append run-body bind-emit bdef/emit (build-bindings node diagram bdef)
+                            ]
                         ]
                         true [
-                            append run-body compose [(to-set-word port-var node 'result) to-float (to-path reduce [face-sym 'text])]
+                            face-sym: to-word rejoin ["f_" node/id]
+                            case [
+                                node-boolean-input? node [
+                                    append run-body compose [(to-set-word port-var node 'result) (to-path reduce [face-sym 'data])]
+                                ]
+                                node-string-input? node [
+                                    append run-body compose [(to-set-word port-var node 'result) (to-path reduce [face-sym 'text])]
+                                ]
+                                true [
+                                    append run-body compose [(to-set-word port-var node 'result) to-float (to-path reduce [face-sym 'text])]
+                                ]
+                            ]
                         ]
                     ]
                 ]
@@ -596,6 +621,9 @@ compile-diagram: func [
         bdef: find-block node/type
         if none? bdef [continue]
         if bdef/category = 'input [
+            ; Array control: sin widget — valor fijo, no aparece en UI layout
+            if node-array-input? node [continue]
+
             face-n: to-word rejoin ["f_" node/id]
             ; any [none false] = none en Red (false es falsy) → usar either/none? explícito
             cfg-val: either none? select node/config 'default [

--- a/src/graph/blocks.red
+++ b/src/graph/blocks.red
@@ -264,4 +264,54 @@ block 'iter 'structure-virtual [
     ; sin emit: la variable _X_N_i ya la genera compile-structure
 ]
 
+; ── Array helpers ─────────────────────────────────────────
+; bind-emit no maneja path! con refinements (copy/part) — se encapsula en función
+arr-subset-helper: func [arr st ln] [copy/part skip arr to-integer st to-integer ln]
+
+; ── Array ─────────────────────────────────────────────────
+
+block 'arr-const 'input [
+    out result 'array
+    config default 'array []
+    emit [result: copy default]
+]
+
+block 'arr-control 'input [
+    out result 'array
+    config default 'array []
+    emit [result: copy default]
+]
+
+block 'arr-indicator 'output [
+    in value 'array
+]
+
+block 'build-array 'array [
+    in a 'number
+    in b 'number
+    out result 'array
+    emit [result: reduce [a b]]
+]
+
+block 'index-array 'array [
+    in arr 'array
+    in index 'number
+    out result 'number
+    emit [result: pick arr to-integer index + 1]
+]
+
+block 'array-size 'array [
+    in arr 'array
+    out result 'number
+    emit [result: to-float length? arr]
+]
+
+block 'array-subset 'array [
+    in arr 'array
+    in start 'number
+    in length 'number
+    out result 'array
+    emit [result: arr-subset-helper arr start length]
+]
+
 #include %../compiler/compiler.red

--- a/src/graph/model.red
+++ b/src/graph/model.red
@@ -249,7 +249,7 @@ make-shift-register: func [
     sr/id:         any [select spec 'id          0]
     sr/data-type:  dt
     sr/init-value: either none? select spec 'init-value [
-        case [dt = 'string [""]  dt = 'boolean [false]  true [0.0]]
+        case [dt = 'string [""]  dt = 'boolean [false]  dt = 'array [copy []]  true [0.0]]
     ][
         select spec 'init-value
     ]

--- a/src/io/file-io.red
+++ b/src/io/file-io.red
@@ -298,6 +298,8 @@ format-qvi: func [
         "    ]^/"
         either empty? fp-str [""] [rejoin ["    front-panel: [^/" fp-str "    ]^/"]]
         "]^/^/"
+        "; --- Helpers de runtime ---^/"
+        "arr-subset-helper: func [arr st ln] [copy/part skip arr to-integer st to-integer ln]^/^/"
         "; --- CÓDIGO GENERADO — no editar, se regenera al guardar ---^/"
         "either empty? system/options/args [^/"
         "    view layout [^/"

--- a/src/ui/diagram/canvas.red
+++ b/src/ui/diagram/canvas.red
@@ -75,6 +75,7 @@ wire-data-color: func [data-type] [
     case [
         data-type = 'boolean [col-wire-bool]
         data-type = 'string  [col-wire-str]
+        data-type = 'array   [col-wire]   ; mismo naranja que number, diferenciado por línea doble
         true                 [col-wire]
     ]
 ]
@@ -93,6 +94,7 @@ sr-type-color: func [data-type] [
     case [
         data-type = 'boolean [col-wire-bool]
         data-type = 'string  [col-wire-str]
+        data-type = 'array   [col-wire]
         true                 [col-wire]
     ]
 ]
@@ -226,15 +228,27 @@ render-wire-list: func [
             mid-x:  to-integer (out-xy/x + in-xy/x) / 2
             wire-dtype: port-out-type src-node wire/from-port
             wire-color: either same? wire selected-wire [col-wire-sel] [wire-data-color wire-dtype]
-            either all [wire-dtype = 'string  not same? wire selected-wire] [
-                append cmds compose [pen (wire-color)  line-width 2]
-                append cmds draw-dashed-segment out-xy              as-pair mid-x out-xy/y
-                append cmds draw-dashed-segment as-pair mid-x out-xy/y  as-pair mid-x in-xy/y
-                append cmds draw-dashed-segment as-pair mid-x in-xy/y  in-xy
-            ][
-                append cmds compose [
-                    pen (wire-color)  line-width 2
-                    line (out-xy) (as-pair mid-x out-xy/y) (as-pair mid-x in-xy/y) (in-xy)
+            case [
+                all [wire-dtype = 'string  not same? wire selected-wire] [
+                    append cmds compose [pen (wire-color)  line-width 2]
+                    append cmds draw-dashed-segment out-xy              as-pair mid-x out-xy/y
+                    append cmds draw-dashed-segment as-pair mid-x out-xy/y  as-pair mid-x in-xy/y
+                    append cmds draw-dashed-segment as-pair mid-x in-xy/y  in-xy
+                ]
+                all [wire-dtype = 'array  not same? wire selected-wire] [
+                    ; Línea doble: trazo grueso exterior + trazo fino interior del color del canvas
+                    append cmds compose [
+                        pen (wire-color)  line-width 4
+                        line (out-xy) (as-pair mid-x out-xy/y) (as-pair mid-x in-xy/y) (in-xy)
+                        pen col-canvas  line-width 1
+                        line (out-xy) (as-pair mid-x out-xy/y) (as-pair mid-x in-xy/y) (in-xy)
+                    ]
+                ]
+                true [
+                    append cmds compose [
+                        pen (wire-color)  line-width 2
+                        line (out-xy) (as-pair mid-x out-xy/y) (as-pair mid-x in-xy/y) (in-xy)
+                    ]
                 ]
             ]
         ]
@@ -283,6 +297,13 @@ render-node-list: func [
             concat         ["CONCAT"]
             str-length     ["LEN"]
             to-string      ["→STR"]
+            arr-const      [rejoin ["[" form any [select node/config 'default  copy []] "]"]]
+            arr-control    ["ARR"]
+            arr-indicator  ["ARR"]
+            build-array    ["BUILD[]"]
+            index-array    ["IDX[]"]
+            array-size     ["SIZE[]"]
+            array-subset   ["SUB[]"]
         ] [uppercase form node/type]
         either all [node/label  object? node/label  node/label/visible] [
             append cmds compose [
@@ -990,6 +1011,56 @@ apply-str-value: func [node new-text /local pos] [
     ]
 ]
 
+; Actualiza node/config 'default con un block! de valores numéricos parseados desde texto.
+; El usuario introduce valores separados por espacios, ej: "1.0 2.0 3.0"
+apply-arr-value: func [node new-text /local pos vals tok parsed-block] [
+    parsed-block: copy []
+    vals: split trim new-text " "
+    foreach tok vals [
+        tok: trim tok
+        if not empty? tok [
+            append parsed-block any [attempt [to-float tok]  attempt [to-integer tok]  0.0]
+        ]
+    ]
+    either pos: find node/config 'default [
+        pos/2: parsed-block
+    ][
+        append node/config reduce ['default parsed-block]
+    ]
+]
+
+arr-apply-and-refresh: func [nd txt cnv] [
+    apply-arr-value nd txt
+    cnv/draw: render-bd cnv/extra
+]
+
+; Abre diálogo para editar el valor de un array constante.
+; El usuario introduce números separados por espacios: "1.0 2.0 3.0"
+open-arr-edit-dialog: func [node canvas-face /local cur-val cur-text] [
+    cur-val: any [select node/config 'default  copy []]
+    cur-text: form cur-val   ; "1.0 2.0 3.0"
+    view/no-wait compose/deep [
+        title "Editar array"
+        text "Valores (separados por espacios):" return
+        field 250 (cur-text)
+        on-enter [
+            arr-apply-and-refresh (node) copy face/text (canvas-face)
+            unview
+        ]
+        return
+        button "OK" [
+            foreach pf face/parent/pane [
+                if pf/type = 'field [
+                    arr-apply-and-refresh (node) copy pf/text (canvas-face)
+                    break
+                ]
+            ]
+            unview
+        ]
+        button "Cancelar" [unview]
+    ]
+]
+
 apply-rename-label: func [node new-text] [
     either empty? new-text [
         if all [node/label  object? node/label] [
@@ -1078,6 +1149,12 @@ open-palette: func [face x y /struct target-struct] [
         button 80 "Concat"   [palette-add-node 'concat]         return
         button 80 "Len"      [palette-add-node 'str-length]
         button 80 "→STR"     [palette-add-node 'to-string]      return
+        text "Array:"  return
+        button 80 "Arr-Const" [palette-add-node 'arr-const]
+        button 80 "Build[]"   [palette-add-node 'build-array]    return
+        button 80 "Index[]"   [palette-add-node 'index-array]
+        button 80 "Size[]"    [palette-add-node 'array-size]     return
+        button 80 "Subset[]"  [palette-add-node 'array-subset]   return
         text "Estructuras:"  return
         button 80 "While"    [palette-add-structure 'while-loop]
         button 80 "For"      [palette-add-structure 'for-loop]   return
@@ -1732,6 +1809,7 @@ render-diagram: func [model canvas-width canvas-height /local canvas-face] [
                     node: st-hit/2
                     if node/type = 'const [open-const-edit-dialog node face  exit]
                     if find [str-const str-control] node/type [open-str-edit-dialog node face  exit]
+                    if find [arr-const arr-control] node/type [open-arr-edit-dialog node face  exit]
                     rename-dialog-node:   node
                     rename-dialog-canvas: face
                     rename-dialog-field:  none
@@ -1767,6 +1845,10 @@ render-diagram: func [model canvas-width canvas-height /local canvas-face] [
                     ]
                     if find [str-const str-control] node/type [
                         open-str-edit-dialog node face
+                        exit
+                    ]
+                    if find [arr-const arr-control] node/type [
+                        open-arr-edit-dialog node face
                         exit
                     ]
                     rename-dialog-node:   node

--- a/src/ui/panel/panel.red
+++ b/src/ui/panel/panel.red
@@ -24,11 +24,11 @@ fp-run-button-height: 30
 fp-text-dy: either system/platform = 'Linux [8] [0]
 
 fp-color?: func [item-type] [
-    either find [control bool-control str-control] item-type [fp-control-color] [fp-indicator-color]
+    either find [control bool-control str-control arr-control] item-type [fp-control-color] [fp-indicator-color]
 ]
 
 fp-border-color?: func [item-type] [
-    either find [control bool-control str-control] item-type [fp-control-color - 20.20.20] [fp-indicator-color - 20.20.20]
+    either find [control bool-control str-control arr-control] item-type [fp-control-color - 20.20.20] [fp-indicator-color - 20.20.20]
 ]
 
 fp-type-label?: func [item-type] [
@@ -39,6 +39,8 @@ fp-type-label?: func [item-type] [
         item-type = 'bool-indicator ["TF"]
         item-type = 'str-control    ["STR"]
         item-type = 'str-indicator  ["STR"]
+        item-type = 'arr-control    ["ARR"]
+        item-type = 'arr-indicator  ["ARR"]
         true                        [uppercase form item-type]
     ]
 ]
@@ -52,6 +54,8 @@ fp-default-label: func [item-type] [
         item-type = 'bool-indicator ["Boolean"]
         item-type = 'str-control    ["String"]
         item-type = 'str-indicator  ["String"]
+        item-type = 'arr-control    ["Array"]
+        item-type = 'arr-indicator  ["Array"]
         true                        ["Numeric"]
     ]
 ]
@@ -68,6 +72,7 @@ make-fp-item: func [
         data-type: case [
             find [bool-control bool-indicator] raw-type ['boolean]
             find [str-control  str-indicator]  raw-type ['string]
+            find [arr-control  arr-indicator]  raw-type ['array]
             true                               ['numeric]
         ]
         name:      any [select spec 'name      ""]
@@ -80,6 +85,10 @@ make-fp-item: func [
                 ; copy siempre: las literales "" en Red son constantes compartidas
                 copy any [select spec 'default  ""]
             ]
+            find [arr-control arr-indicator] raw-type [
+                ; copy siempre: los bloques [] son constantes compartidas en Red
+                copy any [select spec 'default  copy []]
+            ]
             true [
                 any [select spec 'default  0.0]
             ]
@@ -88,9 +97,12 @@ make-fp-item: func [
         offset:    any [select spec 'offset    0x0]
     ]
     item/type: raw-type
-    ; copy para strings: garantiza que control e indicador son objetos independientes
+    ; copy para strings y arrays: garantiza que control e indicador son objetos independientes
     item/value: case [
         find [str-control str-indicator] raw-type [
+            copy any [select spec 'value  item/default]
+        ]
+        find [arr-control arr-indicator] raw-type [
             copy any [select spec 'value  item/default]
         ]
         true [
@@ -144,7 +156,11 @@ make-fp-item: func [
 ]
 
 fp-value-text: func [item] [
-    form item/value
+    either block? item/value [
+        rejoin ["[" form item/value "]"]
+    ][
+        form item/value
+    ]
 ]
 
 ; ══════════════════════════════════════════════════════════
@@ -213,7 +229,8 @@ render-fp-item: func [item selected? /local cmds col border-col type-lbl led-col
     ]
 
     ; ── Body ─────────────────────────────────────────────────────────────────────────────
-    either item/data-type = 'string [
+    case [
+        item/data-type = 'string [
         ; String: campo blanco a partir de item/offset
         either item/type = 'str-control [
             append cmds compose [
@@ -232,7 +249,34 @@ render-fp-item: func [item selected? /local cmds col border-col type-lbl led-col
             pen 20.20.20  fill-pen off
             text (as-pair (item/offset/x + 4) (item/offset/y + 4 + fp-text-dy)) (fp-value-text item)
         ]
-    ][
+    ]
+        item/data-type = 'array [
+        ; Array: caja de color con borde doble + valor como texto
+        col: fp-color? item/type
+        border-col: fp-border-color? item/type
+        ; Borde exterior
+        append cmds compose [
+            pen (border-col)  line-width 3  fill-pen (col)
+            box (as-pair item/offset/x item/offset/y)
+               (as-pair (item/offset/x + fp-item-width) (item/offset/y + fp-item-height)) 4
+        ]
+        ; Borde interior (doble)
+        append cmds compose [
+            pen (col + 20.20.20)  line-width 1  fill-pen off
+            box (as-pair (item/offset/x + 4) (item/offset/y + 4))
+               (as-pair (item/offset/x + fp-item-width - 4) (item/offset/y + fp-item-height - 4)) 3
+        ]
+        append cmds compose [
+            pen 220.230.240  fill-pen off
+            text (as-pair (item/offset/x + 4) (item/offset/y + 5 + fp-text-dy)) "ARR"
+        ]
+        append cmds compose [
+            pen 255.255.255  fill-pen off
+            text (as-pair (item/offset/x + 4) (item/offset/y + fp-item-height - 14 + fp-text-dy))
+                 (fp-value-text item)
+        ]
+    ]
+        true [
         ; Numeric / Boolean: caja de color
         col: fp-color? item/type
         border-col: fp-border-color? item/type
@@ -262,6 +306,7 @@ render-fp-item: func [item selected? /local cmds col border-col type-lbl led-col
             ]
         ]
     ]
+    ]  ; end case
 
     ; ── Selección: marcos rallados en body y label ────────────────────────────────────────
     bh: either item/data-type = 'string [fp-label-height] [fp-item-height]
@@ -376,6 +421,44 @@ open-str-fp-edit-dialog: func [item panel-face model /local cur-val] [
     ]
 ]
 
+; Aplica valor array (texto separado por espacios) a un item del FP y refresca.
+fp-arr-apply-and-refresh: func [itm txt pnl mdl /local parts nums v] [
+    parts: split txt " "
+    nums: copy []
+    foreach p parts [
+        v: attempt [to-float p]
+        if v [append nums v]
+    ]
+    itm/value: nums
+    pnl/draw: render-fp-panel mdl mdl/size/x mdl/size/y
+]
+
+; Abre diálogo para editar el valor de un arr-control en el FP.
+open-arr-fp-edit-dialog: func [item panel-face model /local cur-val cur-text] [
+    cur-val: any [item/value  copy []]
+    cur-text: trim form cur-val
+    view/no-wait compose/deep [
+        title "Editar array"
+        text "Valores (separados por espacios):" return
+        field 250 (cur-text)
+        on-enter [
+            fp-arr-apply-and-refresh (item) copy face/text (panel-face) (model)
+            unview
+        ]
+        return
+        button "OK" [
+            foreach pf face/parent/pane [
+                if pf/type = 'field [
+                    fp-arr-apply-and-refresh (item) copy pf/text (panel-face) (model)
+                    break
+                ]
+            ]
+            unview
+        ]
+        button "Cancelar" [unview]
+    ]
+]
+
 open-edit-dialog: func [item panel-face model /local label-text default-text] [
     edit-dialog-item:  item
     edit-dialog-panel: panel-face
@@ -410,23 +493,27 @@ fp-palette-panel: none
 fp-palette-x:     0
 fp-palette-y:     0
 
-fp-palette-add-item: func [item-type /local new-id item model w h _cref nid bd-y] [
+fp-palette-add-item: func [item-type /local new-id item model w h _cref nid bd-y def-val spec] [
     model:  fp-palette-panel/extra
     w:      model/size/x
     h:      model/size/y
     new-id: 1 + length? model/front-panel
-    item: make-fp-item compose/deep [
-        id:      (new-id)
-        type:    (item-type)
-        name:    (rejoin [form item-type "_" new-id])
-        label:   [text: (fp-default-label item-type) visible: true]
-        default: (case [
-            find [bool-control bool-indicator] item-type [false]
-            find [str-control  str-indicator]  item-type [copy ""]
-            true                               [0.0]
-        ])
-        offset:  (as-pair fp-palette-x fp-palette-y)
+    def-val: case [
+        find [bool-control bool-indicator] item-type [false]
+        find [str-control  str-indicator]  item-type [copy ""]
+        find [arr-control  arr-indicator]  item-type [copy []]
+        true                               [0.0]
     ]
+    ; Construir spec con append/only para default: evitar splice de block! values
+    spec: copy []
+    repend spec [to-set-word 'id  new-id  to-set-word 'type  item-type
+                 to-set-word 'name  rejoin [form item-type "_" new-id]]
+    append spec to-set-word 'label
+    append/only spec compose/deep [text: (fp-default-label item-type) visible: true]
+    append spec to-set-word 'default
+    either block? def-val [append/only spec def-val] [append spec def-val]
+    repend spec [to-set-word 'offset  as-pair fp-palette-x fp-palette-y]
+    item: make-fp-item spec
     append model/front-panel item
     fp-palette-panel/draw: render-fp-panel model w h
     show fp-palette-panel
@@ -460,6 +547,8 @@ open-fp-palette: func [face x y] [
         button 100 "Bool Indicator" [fp-palette-add-item 'bool-indicator] return
         button 100 "Str Control"    [fp-palette-add-item 'str-control]    return
         button 100 "Str Indicator"  [fp-palette-add-item 'str-indicator]  return
+        button 100 "Arr Control"    [fp-palette-add-item 'arr-control]    return
+        button 100 "Arr Indicator"  [fp-palette-add-item 'arr-indicator]  return
         button      "Cancelar"      [unview]
     ]
 ]
@@ -558,6 +647,9 @@ render-panel: func [model panel-width panel-height /local panel-face] [
                     all [hit  hit/type = 'str-control] [
                         open-str-fp-edit-dialog hit face face/extra
                     ]
+                    all [hit  hit/type = 'arr-control] [
+                        open-arr-fp-edit-dialog hit face face/extra
+                    ]
                     all [hit  hit/type = 'control] [
                         open-edit-dialog hit face face/extra
                     ]
@@ -575,6 +667,7 @@ render-panel: func [model panel-width panel-height /local panel-face] [
                         face/draw: render-fp-panel face/extra face/extra/size/x face/extra/size/y
                     ]
                     all [hit  hit/type = 'str-control]   [open-str-fp-edit-dialog hit face face/extra]
+                    all [hit  hit/type = 'arr-control]   [open-arr-fp-edit-dialog hit face face/extra]
                     all [hit  hit/type = 'control]        [open-edit-dialog hit face face/extra]
                     ; indicador: no hacer nada
                 ]
@@ -626,13 +719,14 @@ load-panel-from-diagram: func [diagram-block /local fp-block fp-item-spec result
         offset-y: 20
         parse fp-block [
             any [
-                set kw ['control | 'indicator | 'bool-control | 'bool-indicator | 'str-control | 'str-indicator]
+                set kw ['control | 'indicator | 'bool-control | 'bool-indicator | 'str-control | 'str-indicator | 'arr-control | 'arr-indicator]
                 set fp-item-spec block! (
                     item: make-fp-item fp-item-spec
                     item/type:      kw
                     item/data-type: case [
                         find [bool-control bool-indicator] kw ['boolean]
                         find [str-control  str-indicator]  kw ['string]
+                        find [arr-control  arr-indicator]  kw ['array]
                         true                               ['numeric]
                     ]
                     if all [zero? item/offset/x  zero? item/offset/y] [
@@ -661,16 +755,19 @@ save-panel-to-diagram: func [front-panel-items /local items item kw spec] [
             item/type = 'bool-indicator ['bool-indicator]
             item/type = 'str-control    ['str-control]
             item/type = 'str-indicator  ['str-indicator]
+            item/type = 'arr-control    ['arr-control]
+            item/type = 'arr-indicator  ['arr-indicator]
             true                        ['indicator]
         ]
-        spec: compose/deep [
-            id: (item/id)
-            type: (item/type)
-            name: (item/name)
-            label: [text: (item/label/text) visible: (item/label/visible) offset: (item/label/offset)]
-            default: (item/default)
-            offset: (item/offset)
-        ]
+        ; Construir spec con append/only para el default:
+        ; compose/deep aplana block! values (splice) — no es válido para arr-control
+        spec: copy []
+        repend spec [to-set-word 'id  item/id  to-set-word 'type  item/type  to-set-word 'name  item/name]
+        append spec to-set-word 'label
+        append/only spec compose/deep [text: (item/label/text) visible: (item/label/visible) offset: (item/label/offset)]
+        append spec to-set-word 'default
+        either block? item/default [append/only spec copy item/default] [append spec item/default]
+        repend spec [to-set-word 'offset  item/offset]
         append items kw
         append/only items spec
     ]
@@ -719,7 +816,16 @@ compile-panel: func [model /local cmds item ctrl-field-name ind-var-name] [
                     return
                 ]
             ]
-            true [  ; indicator, bool-indicator, str-indicator
+            item/type = 'arr-control [
+                ; Array control: valor fijo en el .qvi (no hay field editable — DT-028)
+                ind-var-name: gen-indicator-var-name item
+                append cmds compose [
+                    label (item/label/text)
+                    (to-set-word ind-var-name) text 120 (rejoin ["[" form item/default "]"])
+                    return
+                ]
+            ]
+            true [  ; indicator, bool-indicator, str-indicator, arr-indicator
                 ind-var-name: gen-indicator-var-name item
                 append cmds compose [
                     label (item/label/text)

--- a/tests/run-all.red
+++ b/tests/run-all.red
@@ -33,6 +33,7 @@ do %test-blocks.red
 do %test-model.red
 do %test-topo-sort.red
 do %test-compiler.red
+do %test-array.red
 
 ; ── Resumen ──────────────────────────────────────────────────────────
 total: pass-count + fail-count

--- a/tests/test-array.red
+++ b/tests/test-array.red
@@ -1,0 +1,168 @@
+Red [Title: "QTorres — Tests Array 1D"]
+
+do %../src/graph/blocks.red
+
+; ── Registro de bloques ───────────────────────────────────────────────────
+
+suite "array — registro de bloques"
+
+assert "arr-const registrado"     (not none? find-block 'arr-const)
+assert "arr-control registrado"   (not none? find-block 'arr-control)
+assert "arr-indicator registrado" (not none? find-block 'arr-indicator)
+assert "build-array registrado"   (not none? find-block 'build-array)
+assert "index-array registrado"   (not none? find-block 'index-array)
+assert "array-size registrado"    (not none? find-block 'array-size)
+assert "array-subset registrado"  (not none? find-block 'array-subset)
+
+suite "array — puertos"
+
+b-arr-ctrl: find-block 'arr-control
+assert "arr-control tiene 1 salida"         (1 = length? b-arr-ctrl/outputs)
+assert "arr-control output es 'array"       ('array = b-arr-ctrl/outputs/1/type)
+assert "arr-control tiene config default"   (1 = length? b-arr-ctrl/configs)
+
+b-arr-ind: find-block 'arr-indicator
+assert "arr-indicator tiene 1 entrada"      (1 = length? b-arr-ind/inputs)
+assert "arr-indicator input es 'array"      ('array = b-arr-ind/inputs/1/type)
+
+b-build: find-block 'build-array
+assert "build-array tiene 2 entradas"       (2 = length? b-build/inputs)
+assert "build-array tiene 1 salida 'array"  ('array = b-build/outputs/1/type)
+
+b-idx: find-block 'index-array
+assert "index-array tiene 2 entradas"       (2 = length? b-idx/inputs)
+assert "index-array output es 'number"      ('number = b-idx/outputs/1/type)
+
+b-size: find-block 'array-size
+assert "array-size tiene 1 entrada 'array"  ('array = b-size/inputs/1/type)
+assert "array-size output es 'number"       ('number = b-size/outputs/1/type)
+
+b-sub: find-block 'array-subset
+assert "array-subset tiene 3 entradas"      (3 = length? b-sub/inputs)
+assert "array-subset output es 'array"      ('array = b-sub/outputs/1/type)
+
+; ── bind-emit con block values ────────────────────────────────────────────
+
+suite "array — bind-emit con block values"
+
+test-emit: [result: copy default]
+test-bindings: copy []
+append test-bindings 'result
+append test-bindings 'myarr_result
+append test-bindings 'default
+append/only test-bindings [1.0 2.0 3.0]
+
+result-emit: bind-emit test-emit test-bindings
+assert "bind-emit preserva block value (3 elementos)"  (3 = length? result-emit)
+assert "bind-emit: set-word correcto"    (result-emit/1 = to-set-word 'myarr_result)
+assert "bind-emit: copy intacto"         (result-emit/2 = 'copy)
+assert "bind-emit: block value preservado" (block? result-emit/3)
+assert "bind-emit: block value correcto"   (result-emit/3 = [1.0 2.0 3.0])
+
+; ── compile-body con arr-const ───────────────────────────────────────────
+
+suite "array — compile-body arr-const"
+
+; Usar nombres explícitos para evitar guiones en identificadores Red
+d-arr: make-diagram "test-array"
+n-ac: make-node [id: 1  type: 'arr-const  name: "ac1"  x: 50  y: 50]
+n-ac/config: copy [default [1.0 2.0 3.0]]
+n-sz: make-node [id: 2  type: 'array-size  name: "sz1"  x: 200  y: 50]
+n-ind: make-node [id: 3  type: 'indicator  name: "ind1"  x: 350  y: 50]
+
+append d-arr/nodes n-ac
+append d-arr/nodes n-sz
+append d-arr/nodes n-ind
+
+append d-arr/wires make-wire [from: 1  from-port: 'result  to: 2  to-port: 'arr]
+append d-arr/wires make-wire [from: 2  from-port: 'result  to: 3  to-port: 'value]
+
+body: compile-body d-arr
+do body
+
+assert "arr-const produce array correcto"   ([1.0 2.0 3.0] = ac1_result)
+assert "array-size devuelve longitud 3.0"   (3.0 = sz1_result)
+
+; ── index-array ──────────────────────────────────────────────────────────
+
+suite "array — index-array"
+
+d-idx: make-diagram "test-index"
+n-src: make-node [id: 1  type: 'arr-const  name: "src2"  x: 50  y: 50]
+n-src/config: copy [default [10.0 20.0 30.0]]
+n-i: make-node [id: 2  type: 'const  name: "idx2"  x: 200  y: 50]
+n-i/config: copy [default 1.0]   ; índice 1 (0-based) → segundo elemento
+n-ix: make-node [id: 3  type: 'index-array  name: "ix2"  x: 350  y: 50]
+n-o: make-node [id: 4  type: 'indicator  name: "out2"  x: 500  y: 50]
+
+append d-idx/nodes n-src
+append d-idx/nodes n-i
+append d-idx/nodes n-ix
+append d-idx/nodes n-o
+
+append d-idx/wires make-wire [from: 1  from-port: 'result  to: 3  to-port: 'arr]
+append d-idx/wires make-wire [from: 2  from-port: 'result  to: 3  to-port: 'index]
+append d-idx/wires make-wire [from: 3  from-port: 'result  to: 4  to-port: 'value]
+
+body-idx: compile-body d-idx
+do body-idx
+
+; índice 1.0 → to-integer(1.0) + 1 = 2 → pick [10.0 20.0 30.0] 2 = 20.0
+assert "index-array índice 1 → 20.0"  (20.0 = ix2_result)
+
+; ── build-array ──────────────────────────────────────────────────────────
+
+suite "array — build-array"
+
+d-build: make-diagram "test-build"
+n-c1: make-node [id: 1  type: 'const  name: "c1"  x: 50  y: 50]
+n-c1/config: copy [default 5.0]
+n-c2: make-node [id: 2  type: 'const  name: "c2"  x: 50  y: 120]
+n-c2/config: copy [default 7.0]
+n-ba: make-node [id: 3  type: 'build-array  name: "ba1"  x: 200  y: 80]
+n-bo: make-node [id: 4  type: 'arr-indicator  name: "bo1"  x: 350  y: 80]
+
+append d-build/nodes n-c1
+append d-build/nodes n-c2
+append d-build/nodes n-ba
+append d-build/nodes n-bo
+
+append d-build/wires make-wire [from: 1  from-port: 'result  to: 3  to-port: 'a]
+append d-build/wires make-wire [from: 2  from-port: 'result  to: 3  to-port: 'b]
+append d-build/wires make-wire [from: 3  from-port: 'result  to: 4  to-port: 'value]
+
+body-build: compile-body d-build
+do body-build
+
+assert "build-array produce [5.0 7.0]"  ([5.0 7.0] = ba1_result)
+
+; ── array-subset ─────────────────────────────────────────────────────────
+
+suite "array — array-subset"
+
+d-ss: make-diagram "test-subset"
+n-ss-src: make-node [id: 1  type: 'arr-const  name: "ss-src"  x: 50  y: 50]
+n-ss-src/config: copy [default [1.0 2.0 3.0 4.0 5.0]]
+n-ss-st: make-node [id: 2  type: 'const  name: "ss-st"  x: 50  y: 120]
+n-ss-st/config: copy [default 1.0]   ; start=1
+n-ss-ln: make-node [id: 3  type: 'const  name: "ss-ln"  x: 50  y: 190]
+n-ss-ln/config: copy [default 3.0]   ; length=3
+n-ss: make-node [id: 4  type: 'array-subset  name: "ss1"  x: 250  y: 100]
+n-ss-o: make-node [id: 5  type: 'arr-indicator  name: "ss-o"  x: 400  y: 100]
+
+append d-ss/nodes n-ss-src
+append d-ss/nodes n-ss-st
+append d-ss/nodes n-ss-ln
+append d-ss/nodes n-ss
+append d-ss/nodes n-ss-o
+
+append d-ss/wires make-wire [from: 1  from-port: 'result  to: 4  to-port: 'arr]
+append d-ss/wires make-wire [from: 2  from-port: 'result  to: 4  to-port: 'start]
+append d-ss/wires make-wire [from: 3  from-port: 'result  to: 4  to-port: 'length]
+append d-ss/wires make-wire [from: 4  from-port: 'result  to: 5  to-port: 'value]
+
+body-ss: compile-body d-ss
+do body-ss
+
+; skip [1 2 3 4 5] 1 → [2 3 4 5], copy/part 3 → [2 3 4] = [2.0 3.0 4.0]
+assert "array-subset start=1 length=3 → [2.0 3.0 4.0]"  ([2.0 3.0 4.0] = ss1_result)

--- a/tests/test-blocks.red
+++ b/tests/test-blocks.red
@@ -4,7 +4,7 @@ do %../src/graph/blocks.red
 
 suite "blocks — registro"
 
-assert "registra 26 bloques (8 originales + 9 booleanos + 6 string + 3 estructura+virtual)" (26 = length? block-registry)
+assert "registra 33 bloques (26 anteriores + 7 array)" (33 = length? block-registry)
 assert "const está en el registro"     (not none? find-block 'const)
 assert "add está en el registro"       (not none? find-block 'add)
 assert "find-block devuelve none para bloques inexistentes" (none? find-block 'nonexistent)


### PR DESCRIPTION
## Summary

- 7 bloques nuevos: `arr-const`, `arr-control`, `arr-indicator`, `build-array`, `index-array`, `array-size`, `array-subset`
- Wires de tipo `array` con doble línea (naranja exterior + blanco interior), igual que LabVIEW
- Front Panel: control azul y indicador amarillo con badge `ARR` y double border visual
- Diálogos de edición para `arr-const` (BD) y `arr-control` (FP) — valores separados por espacios
- `arr-subset-helper` incluido en preamble del `.qvi` generado (DT-028 compliant)
- Compiler: `build-bindings` y `bind-emit` corregidos para `block!` defaults (append/only)
- `make-shift-register` soporta tipo `'array` → `copy []`
- 30 tests nuevos en `test-array.red`, total **301/301 pasando**

## Test plan

- [x] Tests automatizados: `red-cli tests/run-all.red` → 301/301 OK
- [x] Wire array doble borde visible en BD
- [x] `arr-const` muestra valor entre corchetes, doble clic abre diálogo
- [x] `arr-control` en FP editable con clic/doble clic
- [x] `arr-indicator` en FP muestra valor actualizado tras Run
- [x] `.qvi` generado contiene `arr-subset-helper` y ejecuta sin error

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)