### PR TITLE
fix(fase3): bugs #48 #50 #51 + QA-024/029

### DIFF
--- a/src/compiler/compiler.red
+++ b/src/compiler/compiler.red
@@ -738,9 +738,45 @@ compile-body: func [
 compile-diagram: func [
     diagram [object!]
     /local sorted headless run-body ui-layout item node bdef face-n cfg-val w src src-var bindings
+            ind-label ind-var
 ][
     sorted:   build-sorted-items diagram
     headless: compile-body diagram
+
+    ; ── Añadir prints para indicadores en modo headless (bug #50) ──
+    ; Al final del bloque headless, imprimir valores de todos los indicators
+    foreach item sorted [
+        if in item 'shift-regs [continue]  ; saltar estructuras
+        node: item
+        bdef: find-block node/type
+        if all [bdef  bdef/category = 'output] [
+            ; Buscar si hay wire conectado a este indicador
+            foreach w diagram/wires [
+                if w/to-node = node/id [
+                    ; Encontrar la fuente del valor
+                    src: find-node-by-id diagram/nodes w/from-node
+                    if src [
+                        src-var: port-var src to-word w/from-port
+                        ind-label: either all [node/label  object? node/label] [node/label/text] [node/name]
+                        ind-var: port-var node 'result
+                        ; Generar: print "Label: valor"
+                        append headless compose [print rejoin [(ind-label) ": " form (src-var)]]
+                    ]
+                    ; Fuente: estructura (SR-right → indicador externo)
+                    if all [in diagram 'structures  block? diagram/structures] [
+                        foreach st diagram/structures [
+                            if st/id = w/from-node [
+                                src-var: to-word rejoin ["_" form w/from-port]
+                                ind-label: either all [node/label  object? node/label] [node/label/text] [node/name]
+                                ; Generar: print "Label: valor"
+                                append headless compose [print rejoin [(ind-label) ": " form (src-var)]]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
 
     ; ── Cuerpo del botón Run (modo UI) ────────────────────────
     run-body: copy []

--- a/src/ui/diagram/canvas.red
+++ b/src/ui/diagram/canvas.red
@@ -191,7 +191,11 @@ node-height: func [node /local n-in n-out] [
         any [node/type = 'bundle  node/type = 'unbundle] [
             n-in:  length? in-ports node
             n-out: length? out-ports node
-            max block-height (12 + (max n-in n-out) * 20 + 10)
+            either (n-in = 0) and (n-out = 0) [
+                40
+            ][
+                max block-height (12 + (max n-in n-out) * 20 + 10)
+            ]
         ]
         true [block-height]
     ]

--- a/src/ui/panel/panel.red
+++ b/src/ui/panel/panel.red
@@ -79,7 +79,7 @@ fp-default-label: func [item-type] [
         item-type = 'cluster-indicator ["Cluster"]
         item-type = 'waveform-chart   ["Chart"]
         item-type = 'waveform-graph   ["Graph"]
-        true                          ["Numeric"]
+        true                          ["Numeric"]  ; QA-024: fallback para tipos no contemplados
     ]
 ]
 
@@ -783,13 +783,17 @@ fp-palette-add-item: func [item-type /local new-id item model w h _cref nid bd-y
     _cref: select model 'canvas-ref
     if _cref [
         nid:  gen-node-id model
-        bd-y: 20 + ((length? model/nodes) * 75)
+        ; Calcular posición libre: encontrar max-y y colocar debajo
+        max-y: 40
+        foreach nd model/nodes [
+            if nd/y > max-y [max-y: nd/y]
+        ]
         append model/nodes make-node compose [
             id:   (nid)
             type: (item-type)
             name: (item/name)
-            x:    20
-            y:    (bd-y)
+            x:    40
+            y:    (max-y + 60)
         ]
         _cref/draw: render-bd model
         show _cref
@@ -1046,7 +1050,7 @@ save-panel-to-diagram: func [front-panel-items /local items item kw spec] [
         append spec to-set-word 'label
         append/only spec compose/deep [text: (item/label/text) visible: (item/label/visible) offset: (item/label/offset)]
         append spec to-set-word 'default
-        either block? item/default [append/only spec copy item/default] [append spec item/default]
+        either block? item/value [append/only spec copy item/value] [append spec item/value]  ; QA-029: guardar value (valor actual) no default (valor inicial)
         if item/data-type = 'cluster [
             append spec to-set-word 'config
             append/only spec copy any [item/config  copy []]


### PR DESCRIPTION
## Resumen

| Bug | Fichero | Fix |
|-----|---------|-----|
| #48 | canvas.red | bundle/unbundle vacíos: altura mínima 40 cuando no hay puertos |
| #50 | compiler.red | headless: imprime valores de indicadores al ejecutar con red-cli |
| #51 | panel.red | nodos FP→BD: posición calculada (max-y+60) en lugar de apilar |
| QA-024 | panel.red | comentario en fallback fp-default-label |
| QA-029 | panel.red | save-panel-to-diagram usa item/value (no item/default) |

## Pendiente

- #49 (str-control auto-update) — GTK-010, difícil de reproducir sin GUI, se investiga aparte

## Test plan

- [x] 450/450 tests pasan

Closes #48, #50, #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)